### PR TITLE
Add Docker test setup and ZIP demo deployment

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -1,0 +1,251 @@
+name: Deploy DokuWiki demo
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: Upload and activate the verified ZIP release
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chordsheets-demo-deployment
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: demo
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Read pinned DokuWiki manifest
+        id: manifest
+        shell: pwsh
+        run: |
+          $manifest = Import-PowerShellDataFile ./deployment/demo-manifest.psd1
+          "url=$($manifest.DokuWiki.Url)" >> $env:GITHUB_OUTPUT
+          "sha256=$($manifest.DokuWiki.Sha256)" >> $env:GITHUB_OUTPUT
+          "root=$($manifest.DokuWiki.RootName)" >> $env:GITHUB_OUTPUT
+
+      - name: Download pinned DokuWiki release
+        shell: bash
+        env:
+          DOKUWIKI_URL: ${{ steps.manifest.outputs.url }}
+        run: |
+          set -euo pipefail
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --output "$RUNNER_TEMP/dokuwiki.tgz" \
+            "$DOKUWIKI_URL"
+
+      - name: Build verified demo ZIP
+        shell: pwsh
+        run: |
+          ./deployment/build-demo-zip.ps1 `
+            -DokuWikiArchive "$env:RUNNER_TEMP/dokuwiki.tgz" `
+            -DokuWikiSha256 '${{ steps.manifest.outputs.sha256 }}' `
+            -DokuWikiRootName '${{ steps.manifest.outputs.root }}' `
+            -OutputArchive "$env:RUNNER_TEMP/dokuwiki-chordsheets-demo.zip"
+
+      - name: Run deployment tests
+        shell: pwsh
+        run: |
+          ./deployment/tests/artifact-build.test.ps1
+          ./deployment/tests/zip-output.test.ps1
+          ./deployment/tests/workflow-policy.test.ps1
+          ./deployment/tests/fail-closed-rollback.test.ps1
+
+      - name: Simulate remote ZIP release and rollback
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --entrypoint bash \
+            --tmpfs /home/www:rw,exec,nosuid,size=128m \
+            -v "$RUNNER_TEMP/dokuwiki-chordsheets-demo.zip:/input/release.zip:ro" \
+            -v "$GITHUB_WORKSPACE/deployment:/repo/deployment:ro" \
+            dokuwiki/dokuwiki:2026-07-14a@sha256:5bab64f737257fa5778b35cc920bd9527fb133a71a7535fb2ef319ecc93b384e \
+            -lc '
+              apt-get update -qq
+              DEBIAN_FRONTEND=noninteractive apt-get install -y -qq unzip >/dev/null
+              /repo/deployment/tests/remote-deploy.integration.sh /input/release.zip
+            '
+
+      - name: Run local DokuWiki smoke test
+        shell: pwsh
+        run: |
+          try {
+            ./docker/smoke-test.ps1
+          } finally {
+            docker compose down --volumes
+          }
+
+      - name: Deploy one ZIP over SFTP and SSH
+        if: ${{ inputs.deploy }}
+        shell: bash
+        env:
+          SSHPASS: ${{ secrets.FTP_PASSWORD }}
+          FTP_SERVER: ${{ secrets.FTP_SERVER }}
+          FTP_USERNAME: ${{ secrets.FTP_USERNAME }}
+          FTP_KNOWN_HOSTS: ${{ vars.FTP_KNOWN_HOSTS }}
+          FTP_PORT: ${{ vars.FTP_PORT }}
+          FTP_REMOTE_PATH: ${{ vars.FTP_REMOTE_PATH }}
+          DEMO_URL: ${{ vars.DEMO_URL }}
+        run: |
+          set -euo pipefail
+
+          : "${SSHPASS:?FTP_PASSWORD is required}"
+          : "${FTP_SERVER:?FTP_SERVER is required}"
+          : "${FTP_USERNAME:?FTP_USERNAME is required}"
+          : "${FTP_KNOWN_HOSTS:?FTP_KNOWN_HOSTS is required}"
+          : "${FTP_REMOTE_PATH:?FTP_REMOTE_PATH is required}"
+          : "${DEMO_URL:?DEMO_URL is required}"
+
+          FTP_PORT=${FTP_PORT:-22}
+          [[ "$FTP_PORT" == '22' ]]
+          [[ "$FTP_SERVER" =~ ^[A-Za-z0-9.-]+$ ]]
+          [[ "$FTP_USERNAME" =~ ^[A-Za-z0-9._-]+$ ]]
+          [[ "$FTP_REMOTE_PATH" == '/home/www/chordsheets-demo' ]]
+          [[ "$DEMO_URL" == 'https://chordsheets.pazureck.de' ]]
+
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends sshpass
+
+          install -d -m 0700 "$HOME/.ssh"
+          printf '%s\n' "$FTP_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          chmod 0600 "$HOME/.ssh/known_hosts"
+
+          ssh_options=(
+            -p "$FTP_PORT"
+            -o BatchMode=no
+            -o PreferredAuthentications=password
+            -o PubkeyAuthentication=no
+            -o StrictHostKeyChecking=yes
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts"
+            -o GlobalKnownHostsFile=/dev/null
+          )
+
+          release_archive="$RUNNER_TEMP/dokuwiki-chordsheets-demo.zip"
+          archive_sha256=$(sha256sum "$release_archive" | awk '{print $1}')
+
+          remote_archive=$(sshpass -e ssh "${ssh_options[@]}" \
+            "$FTP_USERNAME@$FTP_SERVER" \
+            "set -euo pipefail; umask 0077; mkdir -p '$FTP_REMOTE_PATH'; test -d '$FTP_REMOTE_PATH'; test ! -L '$FTP_REMOTE_PATH'; test \"\$(realpath -e '$FTP_REMOTE_PATH')\" = '$FTP_REMOTE_PATH'; mkdir -p '$FTP_REMOTE_PATH/uploads'; test -d '$FTP_REMOTE_PATH/uploads'; test ! -L '$FTP_REMOTE_PATH/uploads'; test \"\$(realpath -e '$FTP_REMOTE_PATH/uploads')\" = '$FTP_REMOTE_PATH/uploads'; chmod 0700 '$FTP_REMOTE_PATH/uploads'; mktemp '$FTP_REMOTE_PATH/uploads/.upload.$GITHUB_SHA.XXXXXX'")
+          [[ "$remote_archive" =~ ^/home/www/chordsheets-demo/uploads/\.upload\.$GITHUB_SHA\.[A-Za-z0-9]{6}$ ]]
+          upload_name=${remote_archive##*/}
+
+          sshpass -e scp \
+            -P "$FTP_PORT" \
+            -o BatchMode=no \
+            -o PreferredAuthentications=password \
+            -o PubkeyAuthentication=no \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o GlobalKnownHostsFile=/dev/null \
+            "$release_archive" \
+            "$FTP_USERNAME@$FTP_SERVER:$remote_archive"
+
+          sshpass -e ssh "${ssh_options[@]}" \
+            "$FTP_USERNAME@$FTP_SERVER" \
+            "bash -s -- '$FTP_REMOTE_PATH' '$GITHUB_SHA' '$archive_sha256' '$upload_name'" \
+            < deployment/remote-deploy.sh
+
+          smoke_failed=0
+          curl --fail --silent --show-error \
+            "$DEMO_URL/doku.php?id=start" \
+            | grep --fixed-strings 'DokuWiki Chordsheets Demo' \
+            >/dev/null || smoke_failed=1
+
+          curl --fail --silent --show-error \
+            "$DEMO_URL/lib/plugins/chordsheets/script.js" \
+            >/dev/null || smoke_failed=1
+
+          protected_paths=(
+            '/install.php'
+            '/conf/'
+            '/conf/local.php'
+            '/conf/users.auth.php'
+            '/conf/acl.auth.php'
+            '/data/'
+            '/data/pages/start.txt'
+          )
+
+          for protected_path in "${protected_paths[@]}"; do
+            status=$(curl --silent --show-error --output /dev/null \
+              --write-out '%{http_code}' \
+              "$DEMO_URL$protected_path") || status=000
+            [[ "$status" == '403' || "$status" == '404' ]] || smoke_failed=1
+          done
+
+          redirect_result=$(curl --silent --show-error --output /dev/null \
+            --write-out '%{http_code} %{redirect_url}' \
+            'http://chordsheets.pazureck.de/') || redirect_result='000'
+          [[ "$redirect_result" =~ ^30[1278]\ https://chordsheets\.pazureck\.de/ ]] || smoke_failed=1
+
+          if [[ "$smoke_failed" -ne 0 ]]; then
+            expected_rollback=$(sshpass -e ssh "${ssh_options[@]}" \
+              "$FTP_USERNAME@$FTP_SERVER" \
+              "if [[ -L '$FTP_REMOTE_PATH/previous' ]]; then readlink '$FTP_REMOTE_PATH/previous'; else printf inactive; fi")
+            [[ "$expected_rollback" == 'inactive' || "$expected_rollback" =~ ^releases/[a-f0-9]{40}$ ]]
+
+            sshpass -e ssh "${ssh_options[@]}" \
+              "$FTP_USERNAME@$FTP_SERVER" \
+              "bash -s -- '$FTP_REMOTE_PATH' '$GITHUB_SHA'" \
+              < deployment/remote-rollback.sh
+
+            rollback_state=$(sshpass -e ssh "${ssh_options[@]}" \
+              "$FTP_USERNAME@$FTP_SERVER" \
+              "if [[ -L '$FTP_REMOTE_PATH/current' ]]; then printf active; else printf inactive; fi")
+            rollback_verification_failed=0
+
+            for protected_path in "${protected_paths[@]}"; do
+              status=$(curl --silent --show-error --output /dev/null \
+                --write-out '%{http_code}' \
+                "$DEMO_URL$protected_path") || status=000
+              [[ "$status" == '403' || "$status" == '404' ]] || rollback_verification_failed=1
+            done
+
+            if [[ "$rollback_state" == 'active' ]]; then
+              [[ "$expected_rollback" =~ ^releases/[a-f0-9]{40}$ ]] || rollback_verification_failed=1
+              curl --fail --silent --show-error \
+                "$DEMO_URL/doku.php?id=start" \
+                | grep --fixed-strings 'DokuWiki Chordsheets Demo' \
+                >/dev/null || rollback_verification_failed=1
+              curl --fail --silent --show-error \
+                "$DEMO_URL/lib/plugins/chordsheets/script.js" \
+                >/dev/null || rollback_verification_failed=1
+            elif [[ "$rollback_state" == 'inactive' ]]; then
+              [[ "$expected_rollback" == 'inactive' ]] || rollback_verification_failed=1
+            else
+              rollback_verification_failed=1
+            fi
+
+            if [[ "$rollback_verification_failed" -ne 0 ]]; then
+              if [[ "$rollback_state" == 'active' && "$expected_rollback" =~ ^releases/[a-f0-9]{40}$ ]]; then
+                rollback_sha=${expected_rollback#releases/}
+                sshpass -e ssh "${ssh_options[@]}" \
+                  "$FTP_USERNAME@$FTP_SERVER" \
+                  "bash -s -- '$FTP_REMOTE_PATH' '$rollback_sha'" \
+                  < deployment/remote-deactivate.sh
+              fi
+
+              post_deactivate_state=$(sshpass -e ssh "${ssh_options[@]}" \
+                "$FTP_USERNAME@$FTP_SERVER" \
+                "if [[ -L '$FTP_REMOTE_PATH/current' ]]; then printf active; else printf inactive; fi")
+              [[ "$post_deactivate_state" == 'inactive' ]]
+              echo 'Rollback verification failed; the unverified release was deactivated.' >&2
+              exit 1
+            fi
+
+            echo 'Remote smoke test failed; rollback completed.' >&2
+            exit 1
+          fi
+
+          echo "Demo ZIP deployment succeeded for $GITHUB_SHA."

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,85 @@
+x-dokuwiki-image: &dokuwiki-image
+  dokuwiki/dokuwiki:2026-07-14a@sha256:5bab64f737257fa5778b35cc920bd9527fb133a71a7535fb2ef319ecc93b384e
+
+services:
+  storage-init:
+    image: *dokuwiki-image
+    user: "0:0"
+    entrypoint: ["/bin/sh", "-eu", "-c"]
+    command:
+      - |
+        mkdir -p /storage/conf /storage/data/pages /storage/lib/plugins
+        cp /seed/local.php /storage/conf/local.php
+        cp /seed/start.txt /storage/data/pages/start.txt
+        chown -R 1000:1000 /storage
+    volumes:
+      - dokuwiki-data:/storage
+      - type: bind
+        source: ./docker/dokuwiki
+        target: /seed
+        read_only: true
+    security_opt:
+      - no-new-privileges:true
+    restart: "no"
+
+  dokuwiki:
+    image: *dokuwiki-image
+    user: "1000:1000"
+    depends_on:
+      storage-init:
+        condition: service_completed_successfully
+    ports:
+      - "127.0.0.1:${DOKUWIKI_PORT:-8080}:8080"
+    environment:
+      PHP_TIMEZONE: Europe/Berlin
+    volumes:
+      - dokuwiki-data:/storage
+      - type: bind
+        source: ./conf
+        target: /storage/lib/plugins/chordsheets/conf
+        read_only: true
+      - type: bind
+        source: ./img
+        target: /storage/lib/plugins/chordsheets/img
+        read_only: true
+      - type: bind
+        source: ./js
+        target: /storage/lib/plugins/chordsheets/js
+        read_only: true
+      - type: bind
+        source: ./plugin.info.txt
+        target: /storage/lib/plugins/chordsheets/plugin.info.txt
+        read_only: true
+      - type: bind
+        source: ./script.js
+        target: /storage/lib/plugins/chordsheets/script.js
+        read_only: true
+      - type: bind
+        source: ./style.css
+        target: /storage/lib/plugins/chordsheets/style.css
+        read_only: true
+      - type: bind
+        source: ./syntax.php
+        target: /storage/lib/plugins/chordsheets/syntax.php
+        read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "--silent",
+          "--fail-with-body",
+          "http://localhost:8080/health.php",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
+    stop_grace_period: 10s
+
+volumes:
+  dokuwiki-data:

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,106 @@
+# DokuWiki demo deployment
+
+The public demo is a normal PHP DokuWiki installation on Webgo. It does not
+need a database. Pages and media live in `shared/data`; configuration, ACLs,
+and users live in `shared/conf`.
+
+## Server prerequisites
+
+- The Webgo subdomain `chordsheets.pazureck.de` points to
+  `/chordsheets-demo/current`.
+- PHP 8.3 is selected for the subdomain.
+- A valid Let's Encrypt certificate is active and HTTP redirects to the same
+  HTTPS hostname.
+- The credentials belong to the SSH/SFTP-capable Webgo main account on port
+  22. A plain FTP-only account is not supported by this workflow.
+- The account provides `bash`, `unzip`, `zipinfo`, `realpath`, `sha256sum`,
+  `stat`, and `php`.
+
+## GitHub environment
+
+The workflow uses the GitHub environment `demo`.
+
+Environment secrets:
+
+- `FTP_SERVER`
+- `FTP_USERNAME`
+- `FTP_PASSWORD`
+
+The `FTP_*` names are retained for compatibility, but the transport is
+encrypted SSH/SCP, not plain FTP.
+
+Environment variables:
+
+- `FTP_PORT=22`
+- `FTP_REMOTE_PATH=/home/www/chordsheets-demo`
+- `DEMO_URL=https://chordsheets.pazureck.de`
+- `FTP_KNOWN_HOSTS=<verified OpenSSH known_hosts line>`
+
+Obtain the server key from the configured SSH hostname and compare its
+fingerprint with an independently trusted value from Webgo before storing the
+complete known-hosts line. Do not disable strict host-key checking and do not
+trust an unverified `ssh-keyscan` result.
+
+The environment is restricted to the `master` branch. The workflow can only be
+started manually and defaults to a build/test-only run. Set its `deploy` input
+to `true` only for an intended release.
+
+## Release process
+
+The workflow builds one verified `dokuwiki-chordsheets-demo.zip`. It creates a
+random, private upload file on the server, uploads exactly that one ZIP with
+SCP, verifies its SHA-256, and extracts it into a fresh staging directory with
+`unzip`. No application files are uploaded individually.
+
+Before extraction, the server CRC-tests the ZIP and rejects unsafe paths,
+links and special files, duplicate case-insensitive names, oversized archives,
+excessive expansion ratios, unsafe persistent storage, and concurrent
+deployments. The enforced demo configuration and ACL are repaired on each
+release while existing users and wiki data are preserved. A validated release
+is activated atomically through the `current` symlink.
+
+The first deployment creates this layout:
+
+```text
+/home/www/chordsheets-demo/
+  current -> releases/<git-sha>
+  releases/
+  shared/
+    conf/
+    data/
+  uploads/
+```
+
+From the second deployment onward, `previous` points to the former release for
+rollback.
+
+The setup boots DokuWiki without `install.php`, enables ACLs, disables
+registration, and grants anonymous users read-only access. Authenticated users
+can later be granted edit access to `demo:*` and `playground:*`.
+
+No default administrator or password is created. Provision the first
+administrator separately over SSH with a precomputed DokuWiki password hash.
+Never place a plaintext administrator password in the repository or release
+artifact, and never expose the web installer.
+
+## Verification
+
+Local checks:
+
+```powershell
+./deployment/tests/artifact-build.test.ps1
+./deployment/tests/zip-output.test.ps1
+./deployment/tests/workflow-policy.test.ps1
+./docker/smoke-test.ps1
+```
+
+The GitHub workflow also simulates two remote releases and both rollback paths
+inside a temporary Docker filesystem. A live deployment succeeds only if the
+start page and plugin asset load, sensitive `conf` and `data` paths remain
+blocked, `install.php` is unavailable, and HTTP redirects to the correct HTTPS
+hostname.
+
+If the smoke test fails, rollback is scoped to the Git SHA that was just
+deployed. With no earlier release, the unsafe `current` link is removed; with a
+previous release, the link is switched back atomically and its public page and
+plugin asset are tested again.

--- a/deployment/build-demo-zip.ps1
+++ b/deployment/build-demo-zip.ps1
@@ -1,0 +1,140 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DokuWikiArchive,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[a-fA-F0-9]{64}$')]
+    [string]$DokuWikiSha256,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[A-Za-z0-9._-]+$')]
+    [string]$DokuWikiRootName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('\.zip$')]
+    [string]$OutputArchive,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RepositoryRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($RepositoryRoot)) {
+    $RepositoryRoot = Join-Path $scriptDirectory '..'
+}
+
+$outputFullPath = [System.IO.Path]::GetFullPath($OutputArchive)
+$outputDirectory = Split-Path -Parent $outputFullPath
+if (-not (Test-Path -LiteralPath $outputDirectory -PathType Container)) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+}
+
+$buildRoot = Join-Path $outputDirectory ('.demo-zip-build-' + [guid]::NewGuid().ToString('N'))
+$intermediateArchive = Join-Path $buildRoot 'release.tgz'
+$stageRoot = Join-Path $buildRoot 'stage'
+$temporaryZip = Join-Path $buildRoot 'release.zip'
+
+try {
+    New-Item -ItemType Directory -Path $stageRoot -Force | Out-Null
+
+    & (Join-Path $scriptDirectory 'build-demo.ps1') `
+        -DokuWikiArchive $DokuWikiArchive `
+        -DokuWikiSha256 $DokuWikiSha256 `
+        -DokuWikiRootName $DokuWikiRootName `
+        -OutputArchive $intermediateArchive `
+        -RepositoryRoot $RepositoryRoot
+
+    $tarListing = @(& tar -tvzf $intermediateArchive)
+    if ($LASTEXITCODE -ne 0 -or $tarListing.Count -eq 0) {
+        throw 'Verified intermediate release could not be inspected.'
+    }
+    foreach ($line in $tarListing) {
+        if ([string]::IsNullOrWhiteSpace($line) -or $line[0] -notin @('-', 'd')) {
+            throw "Intermediate release contains a non-regular entry: $line"
+        }
+    }
+
+    & tar -xzf $intermediateArchive -C $stageRoot
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Verified intermediate release could not be expanded.'
+    }
+
+    $unsafeFile = Get-ChildItem -LiteralPath $stageRoot -Force -Recurse |
+        Where-Object { $_.Attributes -band [System.IO.FileAttributes]::ReparsePoint } |
+        Select-Object -First 1
+    if ($unsafeFile) {
+        throw "Release staging contains a link or reparse point: $($unsafeFile.FullName)"
+    }
+
+    Add-Type -AssemblyName System.IO.Compression
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $zip = [System.IO.Compression.ZipFile]::Open(
+        $temporaryZip,
+        [System.IO.Compression.ZipArchiveMode]::Create
+    )
+    try {
+        $files = @(Get-ChildItem -LiteralPath $stageRoot -File -Force -Recurse)
+        if ($files.Count -eq 0) {
+            throw 'Release staging directory contains no files.'
+        }
+
+        foreach ($file in $files) {
+            $relativePath = $file.FullName.Substring($stageRoot.Length).TrimStart('\', '/').Replace('\', '/')
+            if ($relativePath -notmatch '^[A-Za-z0-9._+@/-]+$') {
+                throw "Release contains a non-portable path: $relativePath"
+            }
+
+            [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+                $zip,
+                $file.FullName,
+                $relativePath,
+                [System.IO.Compression.CompressionLevel]::Optimal
+            ) | Out-Null
+        }
+    } finally {
+        $zip.Dispose()
+    }
+
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($temporaryZip)
+    try {
+        if ($zip.Entries.Count -eq 0) {
+            throw 'ZIP archive is empty.'
+        }
+
+        $seenEntries = @{}
+        foreach ($entry in $zip.Entries) {
+            $entryName = $entry.FullName
+            $segments = $entryName.Split('/', [System.StringSplitOptions]::RemoveEmptyEntries)
+            $entryKey = $entryName.ToLowerInvariant()
+            $containsTraversal = $segments -contains '..'
+            $isRooted = $entryName.StartsWith('/') -or $entryName -match '^[A-Za-z]:'
+
+            if (
+                $containsTraversal -or
+                $isRooted -or
+                $entryName.Contains('\') -or
+                $entryName -notmatch '^[A-Za-z0-9._+@/-]+$' -or
+                $seenEntries.ContainsKey($entryKey)
+            ) {
+                throw "ZIP archive contains an unsafe or duplicate path: $entryName"
+            }
+
+            $seenEntries[$entryKey] = $true
+        }
+    } finally {
+        $zip.Dispose()
+    }
+
+    Move-Item -LiteralPath $temporaryZip -Destination $outputFullPath -Force
+} finally {
+    if (Test-Path -LiteralPath $buildRoot) {
+        Remove-Item -LiteralPath $buildRoot -Recurse -Force
+    }
+}
+
+Write-Host "Created verified demo ZIP: $outputFullPath"

--- a/deployment/build-demo.ps1
+++ b/deployment/build-demo.ps1
@@ -1,0 +1,149 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DokuWikiArchive,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[a-fA-F0-9]{64}$')]
+    [string]$DokuWikiSha256,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[A-Za-z0-9._-]+$')]
+    [string]$DokuWikiRootName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputArchive,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RepositoryRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($RepositoryRoot)) {
+    $RepositoryRoot = Join-Path $scriptDirectory '..'
+}
+
+$manifest = Import-PowerShellDataFile (Join-Path $scriptDirectory 'demo-manifest.psd1')
+$resolvedRepositoryRoot = (Resolve-Path -LiteralPath $RepositoryRoot).Path
+$resolvedSourceArchive = (Resolve-Path -LiteralPath $DokuWikiArchive).Path
+$outputFullPath = [System.IO.Path]::GetFullPath($OutputArchive)
+$outputDirectory = Split-Path -Parent $outputFullPath
+
+if (-not (Test-Path -LiteralPath $outputDirectory -PathType Container)) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+}
+
+$actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedSourceArchive).Hash.ToLowerInvariant()
+if ($actualSha256 -ne $DokuWikiSha256.ToLowerInvariant()) {
+    throw "DokuWiki checksum mismatch. Expected $DokuWikiSha256 but got $actualSha256."
+}
+
+$archiveEntries = @(& tar -tf $resolvedSourceArchive)
+if ($LASTEXITCODE -ne 0 -or $archiveEntries.Count -eq 0) {
+    throw 'DokuWiki archive could not be listed.'
+}
+
+$expectedPrefix = "$DokuWikiRootName/"
+foreach ($entry in $archiveEntries) {
+    $normalizedEntry = $entry.Replace('\', '/')
+    $segments = $normalizedEntry.Split('/', [System.StringSplitOptions]::RemoveEmptyEntries)
+    $containsTraversal = $segments -contains '..'
+    $isRooted = $normalizedEntry.StartsWith('/') -or $normalizedEntry -match '^[A-Za-z]:'
+
+    if ($containsTraversal -or $isRooted -or (-not $normalizedEntry.StartsWith($expectedPrefix))) {
+        throw "Unsafe or unexpected DokuWiki archive entry: $entry"
+    }
+}
+
+$verboseEntries = @(& tar -tvf $resolvedSourceArchive)
+if ($LASTEXITCODE -ne 0) {
+    throw 'DokuWiki archive metadata could not be inspected.'
+}
+
+foreach ($entry in $verboseEntries) {
+    if ($entry -match '^[lh]') {
+        throw "DokuWiki archive contains a link entry and was rejected: $entry"
+    }
+}
+
+$buildRoot = Join-Path $outputDirectory ('.demo-build-' + [guid]::NewGuid().ToString('N'))
+$expandedRoot = Join-Path $buildRoot 'expanded'
+$stageRoot = Join-Path $buildRoot 'stage'
+$temporaryArchive = Join-Path $buildRoot 'release.tgz'
+
+try {
+    New-Item -ItemType Directory -Path $expandedRoot -Force | Out-Null
+    & tar -xzf $resolvedSourceArchive -C $expandedRoot
+    if ($LASTEXITCODE -ne 0) {
+        throw 'DokuWiki archive could not be expanded.'
+    }
+
+    $expandedDokuWiki = Join-Path $expandedRoot $DokuWikiRootName
+    if (-not (Test-Path -LiteralPath (Join-Path $expandedDokuWiki 'doku.php') -PathType Leaf)) {
+        throw 'DokuWiki archive is missing doku.php.'
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $expandedDokuWiki 'inc\init.php') -PathType Leaf)) {
+        throw 'DokuWiki archive is missing inc/init.php.'
+    }
+
+    Move-Item -LiteralPath $expandedDokuWiki -Destination $stageRoot
+
+    foreach ($mutablePath in $manifest.MutableDokuWikiPaths) {
+        $candidate = Join-Path $stageRoot $mutablePath
+        if (Test-Path -LiteralPath $candidate) {
+            Remove-Item -LiteralPath $candidate -Recurse -Force
+        }
+    }
+
+    $installer = Join-Path $stageRoot 'install.php'
+    if (Test-Path -LiteralPath $installer) {
+        Remove-Item -LiteralPath $installer -Force
+    }
+
+    $pluginTarget = Join-Path $stageRoot 'lib\plugins\chordsheets'
+    New-Item -ItemType Directory -Path $pluginTarget -Force | Out-Null
+
+    foreach ($runtimePath in $manifest.PluginRuntime) {
+        $source = Join-Path $resolvedRepositoryRoot $runtimePath
+        if (-not (Test-Path -LiteralPath $source)) {
+            throw "Required plugin runtime path is missing: $runtimePath"
+        }
+
+        Copy-Item -LiteralPath $source -Destination $pluginTarget -Recurse -Force
+    }
+
+    $topLevelEntries = @(Get-ChildItem -LiteralPath $stageRoot -Force | ForEach-Object { $_.Name })
+    if ($topLevelEntries.Count -eq 0) {
+        throw 'Release staging directory is empty.'
+    }
+
+    & tar -czf $temporaryArchive -C $stageRoot @topLevelEntries
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Release archive could not be created.'
+    }
+
+    $releaseEntries = @(& tar -tf $temporaryArchive) | ForEach-Object { $_.Replace('\', '/') }
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Release archive could not be verified.'
+    }
+
+    foreach ($forbiddenPath in $manifest.ForbiddenReleasePaths) {
+        $match = $releaseEntries | Where-Object {
+            $_ -eq $forbiddenPath -or $_.StartsWith($forbiddenPath)
+        }
+        if ($match) {
+            throw "Forbidden path found in release archive: $forbiddenPath"
+        }
+    }
+
+    Move-Item -LiteralPath $temporaryArchive -Destination $outputFullPath -Force
+} finally {
+    if (Test-Path -LiteralPath $buildRoot) {
+        Remove-Item -LiteralPath $buildRoot -Recurse -Force
+    }
+}
+
+Write-Host "Created verified demo release: $outputFullPath"

--- a/deployment/demo-manifest.psd1
+++ b/deployment/demo-manifest.psd1
@@ -1,0 +1,50 @@
+@{
+    DokuWiki = @{
+        Version  = '2026-07-14a'
+        RootName = 'dokuwiki-2026-07-14a'
+        Url      = 'https://download.dokuwiki.org/src/dokuwiki/dokuwiki-2026-07-14a.tgz'
+        Sha256   = '88a4a37bba7353b883610bbb738c30472af9d4254bd7064495a106f2e8086de3'
+    }
+
+    PluginRuntime = @(
+        'conf'
+        'img'
+        'js'
+        'plugin.info.txt'
+        'script.js'
+        'style.css'
+        'syntax.php'
+    )
+
+    MutableDokuWikiPaths = @(
+        '.git'
+        '.github'
+        '.gitignore'
+        '.travis.yml'
+        '.tx'
+        '_test'
+        'data'
+        'conf/local.php'
+        'conf/local.php.bak'
+        'conf/users.auth.php'
+        'conf/users.auth.php.bak'
+        'conf/acl.auth.php'
+        'conf/acl.auth.php.bak'
+    )
+
+    ForbiddenReleasePaths = @(
+        'install.php'
+        'data/'
+        '.git/'
+        '.github/'
+        '.vscode/'
+        '.codex_tmp/'
+        'docker/'
+        '_test/'
+        'released/'
+        'compose.yaml'
+        'README.md'
+        'CHANGELOG.md'
+        'test.html'
+    )
+}

--- a/deployment/remote-deactivate.sh
+++ b/deployment/remote-deactivate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 0077
+
+remote_root=${1:-}
+expected_sha=${2:-}
+
+[[ "$remote_root" =~ ^/home/www/[A-Za-z0-9._-]+$ ]] || {
+  echo 'Unsafe remote root.' >&2
+  exit 2
+}
+[[ "$expected_sha" =~ ^[a-f0-9]{40}$ ]] || {
+  echo 'Expected release must be a full lowercase Git SHA.' >&2
+  exit 2
+}
+
+test -d "$remote_root"
+test ! -L "$remote_root"
+test "$(realpath -e "$remote_root")" = "$remote_root"
+
+lock="$remote_root/.deploy.lock"
+mkdir "$lock" 2>/dev/null || {
+  echo 'Another deployment operation is active.' >&2
+  exit 5
+}
+locked=1
+cleanup() {
+  if [[ "${locked:-0}" -eq 1 && -d "$lock" && ! -L "$lock" ]]; then
+    rmdir "$lock"
+  fi
+}
+trap cleanup EXIT
+
+test -L "$remote_root/current"
+current_target=$(readlink "$remote_root/current")
+[[ "$current_target" == "releases/$expected_sha" ]] || {
+  echo 'Active release changed; refusing deactivation.' >&2
+  exit 3
+}
+
+rm -f -- "$remote_root/current"
+rmdir "$lock"
+locked=0
+trap - EXIT
+echo "Deactivated unverified release $expected_sha."

--- a/deployment/remote-deploy.sh
+++ b/deployment/remote-deploy.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 0077
+
+root=${1:-}
+sha=${2:-}
+expected_hash=${3:-}
+upload_name=${4:-}
+
+[[ "$root" =~ ^/home/www/[A-Za-z0-9._-]+$ ]] || { echo 'Unsafe remote root.' >&2; exit 2; }
+[[ "$sha" =~ ^[a-f0-9]{40}$ ]] || { echo 'Invalid release SHA.' >&2; exit 2; }
+[[ "$expected_hash" =~ ^[a-f0-9]{64}$ ]] || { echo 'Invalid archive SHA-256.' >&2; exit 2; }
+[[ "$upload_name" =~ ^\.upload\.$sha\.[A-Za-z0-9]{6}$ ]] || { echo 'Invalid upload name.' >&2; exit 2; }
+
+for command_name in unzip zipinfo realpath sha256sum stat php; do
+  command -v "$command_name" >/dev/null || { echo "Missing command: $command_name" >&2; exit 2; }
+done
+
+mkdir -p "$root"
+[[ "$(realpath -e "$root")" == "$root" ]] || { echo 'Remote root resolves through a symlink.' >&2; exit 2; }
+
+uploads="$root/uploads"
+releases="$root/releases"
+shared="$root/shared"
+archive="$uploads/$upload_name"
+release="$releases/$sha"
+staging="$releases/.$sha.tmp"
+lock="$root/.deploy.lock"
+
+for managed in "$uploads" "$releases" "$shared"; do
+  [[ ! -L "$managed" ]] || { echo "Managed path is a symlink: $managed" >&2; exit 2; }
+done
+mkdir -p "$uploads" "$releases" "$shared"
+chmod 0700 "$uploads" "$shared"
+
+[[ -f "$archive" && ! -L "$archive" ]] || { echo 'Uploaded ZIP is missing or unsafe.' >&2; exit 3; }
+archive_bytes=$(stat -c '%s' "$archive")
+(( archive_bytes > 0 && archive_bytes <= 67108864 )) || { echo 'ZIP size is outside the allowed range.' >&2; exit 3; }
+actual_hash=$(sha256sum "$archive" | awk '{print $1}')
+[[ "$actual_hash" == "$expected_hash" ]] || { echo 'Uploaded ZIP checksum mismatch.' >&2; exit 3; }
+
+unzip -tqq "$archive"
+if zipinfo -l "$archive" | grep -Eq '^[lbcps]'; then
+  echo 'ZIP contains a link or special file.' >&2
+  exit 3
+fi
+
+read -r entry_count unpacked_bytes < <(
+  zipinfo -l "$archive" | awk '
+    $1 ~ /^[-d][rwxStTs-]+$/ {
+      entries += 1
+      unpacked += $4
+    }
+    END { printf "%d %d\n", entries, unpacked }
+  '
+)
+(( entry_count > 0 && entry_count <= 25000 )) || { echo 'ZIP entry count is unsafe.' >&2; exit 3; }
+(( unpacked_bytes <= 536870912 )) || { echo 'ZIP expands beyond the size limit.' >&2; exit 3; }
+(( unpacked_bytes <= archive_bytes * 200 )) || { echo 'ZIP compression ratio is unsafe.' >&2; exit 3; }
+
+unzip -Z1 "$archive" | awk '
+  {
+    entry = $0
+    lower = tolower(entry)
+    if (entry == "" || entry == "." || entry ~ /^\// || entry ~ /\\/ || entry ~ /(^|\/)\.\.(\/|$)/ || entry ~ /\/\// || entry !~ /^[A-Za-z0-9._+@\/-]+$/ || seen[lower]++) {
+      bad = 1
+    }
+  }
+  END { exit bad ? 1 : 0 }
+' || { echo 'ZIP contains an unsafe or duplicate path.' >&2; exit 3; }
+
+mkdir "$lock" 2>/dev/null || { echo 'Another deployment is active.' >&2; exit 5; }
+locked=1
+cleanup() {
+  [[ ! -e "$staging" && ! -L "$staging" ]] || rm -rf -- "$staging"
+  if [[ "${locked:-0}" -eq 1 && -d "$lock" && ! -L "$lock" ]]; then
+    rmdir "$lock"
+  fi
+}
+trap cleanup EXIT
+
+[[ ! -e "$release" && ! -L "$release" ]] || { echo 'Release already exists.' >&2; exit 4; }
+[[ ! -e "$staging" && ! -L "$staging" ]] || rm -rf -- "$staging"
+mkdir "$staging"
+unzip -q "$archive" -d "$staging"
+
+if find "$staging" \( -type l -o -type b -o -type c -o -type p -o -type s \) -print -quit | grep -q .; then
+  echo 'Expanded ZIP contains a link or special file.' >&2
+  exit 3
+fi
+
+[[ -f "$staging/doku.php" ]]
+[[ -f "$staging/inc/init.php" ]]
+[[ -f "$staging/lib/plugins/chordsheets/syntax.php" ]]
+[[ ! -e "$staging/install.php" ]]
+[[ ! -e "$staging/data" ]]
+[[ ! -e "$staging/conf/local.php" ]]
+
+for persistent in "$shared/conf" "$shared/data"; do
+  [[ ! -L "$persistent" ]] || { echo "Persistent path is a symlink: $persistent" >&2; exit 2; }
+done
+
+if [[ ! -d "$shared/conf" ]]; then
+  mv "$staging/conf" "$shared/conf"
+else
+  rm -rf -- "$staging/conf"
+fi
+
+if [[ ! -d "$shared/data" ]]; then
+  mkdir -p \
+    "$shared/data/attic" "$shared/data/cache" "$shared/data/index" "$shared/data/locks" \
+    "$shared/data/media" "$shared/data/media_attic" "$shared/data/media_meta" \
+    "$shared/data/meta" "$shared/data/pages" "$shared/data/tmp"
+  cat > "$shared/data/pages/start.txt" <<'START'
+====== DokuWiki Chordsheets Demo ======
+
+This instance runs the current chordsheets plugin from GitHub.
+
+<chordSheet>
+[C]Hello [G]world
+[Am]This is the [F]guitar demo
+</chordSheet>
+
+<chordSheet instrument="ukulele">
+[C]Ukulele [G]preview
+</chordSheet>
+START
+fi
+
+for persistent in "$shared/conf" "$shared/data"; do
+  if find "$persistent" \( -type l -o -type b -o -type c -o -type p -o -type s \) -print -quit | grep -q .; then
+    echo "Persistent tree contains a link or special file: $persistent" >&2
+    exit 4
+  fi
+done
+
+local_tmp="$shared/conf/.local.php.$sha.tmp"
+acl_tmp="$shared/conf/.acl.auth.php.$sha.tmp"
+rm -f -- "$local_tmp" "$acl_tmp"
+cat > "$local_tmp" <<'PHP'
+<?php
+$conf['title'] = 'DokuWiki Chordsheets Demo';
+$conf['lang'] = 'en';
+$conf['license'] = 'cc-by-sa';
+$conf['useacl'] = 1;
+$conf['superuser'] = '@admin';
+$conf['authtype'] = 'authplain';
+$conf['disableactions'] = 'register';
+$conf['breadcrumbs'] = 0;
+$conf['youarehere'] = 1;
+PHP
+cat > "$acl_tmp" <<'ACL'
+# acl.auth.php
+# <?php exit()?>
+*               @ALL        1
+*               @user       1
+demo:*          @user       2
+playground:*    @user       2
+ACL
+chmod 0600 "$local_tmp" "$acl_tmp"
+mv -Tf "$local_tmp" "$shared/conf/local.php"
+mv -Tf "$acl_tmp" "$shared/conf/acl.auth.php"
+
+if [[ ! -e "$shared/conf/users.auth.php" ]]; then
+  users_tmp="$shared/conf/.users.auth.php.$sha.tmp"
+  cat > "$users_tmp" <<'USERS'
+# users.auth.php
+# <?php exit()?>
+USERS
+  chmod 0600 "$users_tmp"
+  mv -T "$users_tmp" "$shared/conf/users.auth.php"
+fi
+[[ -f "$shared/conf/users.auth.php" && ! -L "$shared/conf/users.auth.php" ]]
+
+for protected_dir in "$shared/conf" "$shared/data"; do
+  htaccess_tmp="$protected_dir/.htaccess.$sha.tmp"
+  rm -f -- "$htaccess_tmp"
+  cat > "$htaccess_tmp" <<'HTACCESS'
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Deny from all
+</IfModule>
+HTACCESS
+  chmod 0600 "$htaccess_tmp"
+  mv -Tf "$htaccess_tmp" "$protected_dir/.htaccess"
+done
+
+ln -s ../../shared/conf "$staging/conf"
+ln -s ../../shared/data "$staging/data"
+find "$staging" -type d -exec chmod 0755 {} +
+find "$staging" -type f -exec chmod 0644 {} +
+find "$shared/conf" "$shared/data" -type d -exec chmod 0700 {} +
+find "$shared/conf" "$shared/data" -type f -exec chmod 0600 {} +
+php -l "$staging/lib/plugins/chordsheets/syntax.php" >/dev/null
+
+mv "$staging" "$release"
+[[ ! -e "$release/install.php" ]]
+
+old_target=
+if [[ -e "$root/current" && ! -L "$root/current" ]]; then
+  echo 'Current deployment target is not a symlink.' >&2
+  exit 4
+fi
+if [[ -L "$root/current" ]]; then
+  old_target=$(readlink "$root/current")
+  [[ "$old_target" =~ ^releases/[a-f0-9]{40}$ ]] || { echo 'Current target is invalid.' >&2; exit 4; }
+  old_path="$root/$old_target"
+  [[ -d "$old_path" && ! -L "$old_path" && ! -e "$old_path/install.php" ]]
+  case "$(realpath -e "$old_path")" in
+    "$releases"/*) ;;
+    *) echo 'Current release resolves outside releases.' >&2; exit 4 ;;
+  esac
+fi
+
+for next_link in "$root/current.next" "$root/previous.next"; do
+  [[ ! -e "$next_link" && ! -L "$next_link" ]] || { echo "Stale switch path: $next_link" >&2; exit 4; }
+done
+
+if [[ -n "$old_target" ]]; then
+  ln -s "$old_target" "$root/previous.next"
+  mv -Tf "$root/previous.next" "$root/previous"
+fi
+ln -s "releases/$sha" "$root/current.next"
+mv -Tf "$root/current.next" "$root/current"
+
+rm -f -- "$archive"
+rmdir "$lock"
+locked=0
+trap - EXIT
+echo "Activated release $sha."

--- a/deployment/remote-rollback.sh
+++ b/deployment/remote-rollback.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 0077
+
+remote_root=${1:-}
+failed_sha=${2:-}
+
+if [[ ! "$remote_root" =~ ^/home/www/[A-Za-z0-9._-]+$ ]]; then
+  echo "Remote root must be one direct, safe child below /home/www." >&2
+  exit 2
+fi
+
+if [[ ! "$failed_sha" =~ ^[a-f0-9]{40}$ ]]; then
+  echo "Failed release SHA must be a full lowercase Git commit SHA." >&2
+  exit 2
+fi
+
+test -d "$remote_root"
+if [[ "$(realpath -e "$remote_root")" != "$remote_root" ]]; then
+  echo "Remote root must not resolve through a symlink." >&2
+  exit 2
+fi
+
+releases_dir="$remote_root/releases"
+lock="$remote_root/.deploy.lock"
+test -d "$releases_dir"
+test ! -L "$releases_dir"
+
+mkdir "$lock" 2>/dev/null || { echo 'Another deployment operation is active.' >&2; exit 5; }
+locked=1
+cleanup() {
+  if [[ "${locked:-0}" -eq 1 && -d "$lock" && ! -L "$lock" ]]; then
+    rmdir "$lock"
+  fi
+}
+trap cleanup EXIT
+
+if [[ ! -L "$remote_root/current" ]]; then
+  echo 'No active release exists; nothing to roll back.'
+  exit 0
+fi
+
+current_target=$(readlink "$remote_root/current")
+if [[ "$current_target" != "releases/$failed_sha" ]]; then
+  echo 'Current release is not the failed release; refusing rollback.' >&2
+  exit 3
+fi
+
+if [[ ! -L "$remote_root/previous" ]]; then
+  rm -f -- "$remote_root/current"
+  rmdir "$lock"
+  locked=0
+  trap - EXIT
+  echo "No previous release existed; deactivated $current_target."
+  exit 0
+fi
+
+previous_target=$(readlink "$remote_root/previous")
+if [[ ! "$previous_target" =~ ^releases/[a-f0-9]{40}$ ]]; then
+  echo 'Previous release target is invalid.' >&2
+  exit 3
+fi
+
+previous_path="$remote_root/$previous_target"
+test -d "$previous_path"
+test ! -L "$previous_path"
+test ! -e "$previous_path/install.php"
+test -f "$previous_path/doku.php"
+test -f "$previous_path/inc/init.php"
+test -f "$previous_path/lib/plugins/chordsheets/syntax.php"
+test -L "$previous_path/conf"
+test -L "$previous_path/data"
+test "$(readlink "$previous_path/conf")" = '../../shared/conf'
+test "$(readlink "$previous_path/data")" = '../../shared/data'
+
+resolved_previous=$(realpath -e "$previous_path")
+case "$resolved_previous" in
+  "$releases_dir"/*) ;;
+  *) echo 'Previous release resolves outside the release directory.' >&2; exit 3 ;;
+esac
+
+if [[ -e "$remote_root/current.rollback" || -L "$remote_root/current.rollback" ]]; then
+  rm -f -- "$remote_root/current.rollback"
+fi
+
+ln -s "$previous_target" "$remote_root/current.rollback"
+mv -Tf "$remote_root/current.rollback" "$remote_root/current"
+rmdir "$lock"
+locked=0
+trap - EXIT
+echo "Rolled back to $previous_target."

--- a/deployment/tests/artifact-build.test.ps1
+++ b/deployment/tests/artifact-build.test.ps1
@@ -1,0 +1,123 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$builder = Join-Path $repositoryRoot 'deployment\build-demo.ps1'
+$temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('chordsheets-deploy-test-' + [guid]::NewGuid().ToString('N'))
+$fixtureRoot = Join-Path $temporaryRoot 'dokuwiki-test'
+$fixtureArchive = Join-Path $temporaryRoot 'dokuwiki-test.tgz'
+$outputArchive = Join-Path $temporaryRoot 'demo-release.tgz'
+$expandedOutput = Join-Path $temporaryRoot 'expanded'
+
+function Assert-True {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-ArchiveEntry {
+    param(
+        [string[]]$Entries,
+        [string]$ExpectedEntry
+    )
+
+    Assert-True ($Entries -contains $ExpectedEntry) "Missing archive entry: $ExpectedEntry"
+}
+
+try {
+    New-Item -ItemType Directory -Path (Join-Path $fixtureRoot 'inc') -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $fixtureRoot 'conf') -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $fixtureRoot 'data\pages') -Force | Out-Null
+
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'doku.php') -Value '<?php echo "fixture";'
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'install.php') -Value '<?php echo "installer";'
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'inc\init.php') -Value '<?php'
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'conf\dokuwiki.php') -Value '<?php'
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'conf\local.php') -Value '<?php $conf["unsafe"] = true;'
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'data\pages\start.txt') -Value 'fixture'
+
+    Push-Location $temporaryRoot
+    try {
+        & tar -czf $fixtureArchive 'dokuwiki-test'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not create DokuWiki fixture archive.'
+        }
+    } finally {
+        Pop-Location
+    }
+
+    $fixtureSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $fixtureArchive).Hash.ToLowerInvariant()
+
+    & $builder `
+        -DokuWikiArchive $fixtureArchive `
+        -DokuWikiSha256 $fixtureSha256 `
+        -DokuWikiRootName 'dokuwiki-test' `
+        -OutputArchive $outputArchive `
+        -RepositoryRoot $repositoryRoot
+
+    Assert-True (Test-Path -LiteralPath $outputArchive -PathType Leaf) 'Builder did not create the release archive.'
+
+    New-Item -ItemType Directory -Path $expandedOutput -Force | Out-Null
+    & tar -xzf $outputArchive -C $expandedOutput
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Could not expand the built release archive.'
+    }
+
+    $entries = @(& tar -tf $outputArchive) | ForEach-Object { $_.Replace('\', '/') }
+    Assert-ArchiveEntry $entries 'doku.php'
+    Assert-ArchiveEntry $entries 'inc/init.php'
+    Assert-ArchiveEntry $entries 'lib/plugins/chordsheets/syntax.php'
+    Assert-ArchiveEntry $entries 'lib/plugins/chordsheets/script.js'
+    Assert-ArchiveEntry $entries 'lib/plugins/chordsheets/style.css'
+    Assert-ArchiveEntry $entries 'lib/plugins/chordsheets/plugin.info.txt'
+    Assert-ArchiveEntry $entries 'lib/plugins/chordsheets/conf/default.php'
+    Assert-ArchiveEntry $entries 'lib/plugins/chordsheets/conf/metadata.php'
+
+    $forbiddenPatterns = @(
+        'install.php',
+        'data/',
+        'conf/local.php',
+        '.git/',
+        '.github/',
+        '.vscode/',
+        '.codex_tmp/',
+        'docker/',
+        '_test/',
+        'released/',
+        'compose.yaml',
+        'README.md',
+        'CHANGELOG.md',
+        'test.html'
+    )
+
+    foreach ($pattern in $forbiddenPatterns) {
+        Assert-True (-not ($entries | Where-Object { $_ -eq $pattern -or $_.StartsWith($pattern) })) "Forbidden archive entry found: $pattern"
+    }
+
+    $badChecksumOutput = Join-Path $temporaryRoot 'bad-checksum.tgz'
+    $checksumFailed = $false
+    try {
+        & $builder `
+            -DokuWikiArchive $fixtureArchive `
+            -DokuWikiSha256 ('0' * 64) `
+            -DokuWikiRootName 'dokuwiki-test' `
+            -OutputArchive $badChecksumOutput `
+            -RepositoryRoot $repositoryRoot
+    } catch {
+        $checksumFailed = $true
+    }
+
+    Assert-True $checksumFailed 'Builder accepted an invalid DokuWiki checksum.'
+    Assert-True (-not (Test-Path -LiteralPath $badChecksumOutput)) 'Builder left output behind after checksum failure.'
+
+    Write-Host 'artifact-build.test.ps1: PASS'
+} finally {
+    if (Test-Path -LiteralPath $temporaryRoot) {
+        Remove-Item -LiteralPath $temporaryRoot -Recurse -Force
+    }
+}

--- a/deployment/tests/fail-closed-rollback.test.ps1
+++ b/deployment/tests/fail-closed-rollback.test.ps1
@@ -1,0 +1,39 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$workflowPath = Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml'
+$deactivatePath = Join-Path $repositoryRoot 'deployment\remote-deactivate.sh'
+
+if (-not (Test-Path -LiteralPath $deactivatePath -PathType Leaf)) {
+    throw 'Missing fail-closed remote deactivation script.'
+}
+
+$workflow = Get-Content -Raw -LiteralPath $workflowPath
+$deactivate = Get-Content -Raw -LiteralPath $deactivatePath
+
+foreach ($pattern in @(
+    'realpath -e ''\$FTP_REMOTE_PATH''',
+    'realpath -e ''\$FTP_REMOTE_PATH/uploads''',
+    'rollback_verification_failed',
+    '403'' \|\| \"\$status\" == ''404',
+    'deployment/remote-deactivate\.sh',
+    'post_deactivate_state'
+)) {
+    if ($workflow -notmatch $pattern) {
+        throw "Workflow is missing fail-closed rollback protection: $pattern"
+    }
+}
+
+foreach ($pattern in @(
+    '\.deploy\.lock',
+    '\^\[a-f0-9\]\{40\}\$',
+    'readlink "\$remote_root/current"',
+    'rm -f -- "\$remote_root/current"'
+)) {
+    if ($deactivate -notmatch $pattern) {
+        throw "Remote deactivation is missing a safety invariant: $pattern"
+    }
+}
+
+Write-Host 'fail-closed-rollback.test.ps1: PASS'

--- a/deployment/tests/remote-deploy.integration.sh
+++ b/deployment/tests/remote-deploy.integration.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact=${1:-}
+test -f "$artifact"
+
+deployment_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+deploy_script="$deployment_dir/remote-deploy.sh"
+rollback_script="$deployment_dir/remote-rollback.sh"
+archive_sha256=$(sha256sum "$artifact" | awk '{print $1}')
+
+run_deploy() {
+  local root=$1
+  local sha=$2
+  local suffix=$3
+  local upload_name=".upload.$sha.$suffix"
+  mkdir -p "$root/uploads"
+  cp "$artifact" "$root/uploads/$upload_name"
+  bash "$deploy_script" "$root" "$sha" "$archive_sha256" "$upload_name"
+}
+
+invalid_sha=9999999999999999999999999999999999999999
+if bash "$deploy_script" '/home/www/../escape' "$invalid_sha" "$archive_sha256" ".upload.$invalid_sha.abc123"; then
+  echo 'Deploy accepted a traversing remote root.' >&2
+  exit 1
+fi
+
+first_root=/home/www/chordsheets-demo
+first_sha=1111111111111111111111111111111111111111
+second_sha=2222222222222222222222222222222222222222
+
+run_deploy "$first_root" "$first_sha" abc123
+
+test "$(readlink "$first_root/current")" = "releases/$first_sha"
+test ! -e "$first_root/previous"
+test -L "$first_root/current/conf"
+test -L "$first_root/current/data"
+test -f "$first_root/shared/conf/local.php"
+test -f "$first_root/shared/data/.htaccess"
+test ! -e "$first_root/current/install.php"
+test ! -e "$first_root/uploads/.upload.$first_sha.abc123"
+
+cat > "$first_root/shared/conf/local.php" <<'PHP'
+<?php
+$conf['useacl'] = 0;
+$conf['disableactions'] = '';
+PHP
+cat > "$first_root/shared/conf/acl.auth.php" <<'ACL'
+# deliberately unsafe drift
+*               @ALL        16
+ACL
+cat > "$first_root/shared/conf/users.auth.php" <<'USERS'
+# users.auth.php
+# <?php exit()?>
+demo-user:$2y$10$placeholder:Demo User:user:demo@example.invalid
+USERS
+rm -f -- "$first_root/shared/conf/.htaccess" "$first_root/shared/data/.htaccess"
+
+run_deploy "$first_root" "$second_sha" def456
+
+test "$(readlink "$first_root/current")" = "releases/$second_sha"
+test "$(readlink "$first_root/previous")" = "releases/$first_sha"
+test -f "$first_root/shared/conf/.htaccess"
+test -f "$first_root/shared/data/.htaccess"
+grep -Fq "\$conf['useacl'] = 1;" "$first_root/shared/conf/local.php"
+grep -Fq "\$conf['disableactions'] = 'register';" "$first_root/shared/conf/local.php"
+grep -Fq '*               @ALL        1' "$first_root/shared/conf/acl.auth.php"
+grep -Fq 'demo-user:$2y$10$placeholder' "$first_root/shared/conf/users.auth.php"
+
+symlink_sha=5555555555555555555555555555555555555555
+ln -s /tmp "$first_root/shared/data/cache/unsafe-link"
+mkdir -p "$first_root/uploads"
+cp "$artifact" "$first_root/uploads/.upload.$symlink_sha.ghi789"
+if bash "$deploy_script" "$first_root" "$symlink_sha" "$archive_sha256" ".upload.$symlink_sha.ghi789"; then
+  echo 'Deploy accepted a symlink in persistent storage.' >&2
+  exit 1
+fi
+test "$(readlink "$first_root/current")" = "releases/$second_sha"
+rm -f -- "$first_root/shared/data/cache/unsafe-link" "$first_root/uploads/.upload.$symlink_sha.ghi789"
+
+mkdir "$first_root/.deploy.lock"
+if bash "$rollback_script" "$first_root" "$second_sha"; then
+  echo 'Rollback ignored an active deployment lock.' >&2
+  exit 1
+fi
+test "$(readlink "$first_root/current")" = "releases/$second_sha"
+rmdir "$first_root/.deploy.lock"
+
+ln -sfn 'releases/11111111../../shared' "$first_root/previous"
+if bash "$rollback_script" "$first_root" "$second_sha"; then
+  echo 'Rollback accepted a malformed previous target.' >&2
+  exit 1
+fi
+test "$(readlink "$first_root/current")" = "releases/$second_sha"
+
+ln -sfn "releases/$first_sha" "$first_root/previous"
+bash "$rollback_script" "$first_root" "$second_sha"
+test "$(readlink "$first_root/current")" = "releases/$first_sha"
+
+bootstrap_root=/home/www/chordsheets-bootstrap
+bootstrap_sha=3333333333333333333333333333333333333333
+run_deploy "$bootstrap_root" "$bootstrap_sha" jkl012
+test "$(readlink "$bootstrap_root/current")" = "releases/$bootstrap_sha"
+test ! -e "$bootstrap_root/previous"
+
+bash "$rollback_script" "$bootstrap_root" "$bootstrap_sha"
+test ! -e "$bootstrap_root/current"
+
+locked_root=/home/www/chordsheets-locked
+locked_sha=4444444444444444444444444444444444444444
+mkdir -p "$locked_root/uploads" "$locked_root/.deploy.lock"
+cp "$artifact" "$locked_root/uploads/.upload.$locked_sha.mno345"
+if bash "$deploy_script" "$locked_root" "$locked_sha" "$archive_sha256" ".upload.$locked_sha.mno345"; then
+  echo 'Deploy ignored an active deployment lock.' >&2
+  exit 1
+fi
+test ! -e "$locked_root/current"
+
+echo 'remote-deploy.integration.sh: PASS'

--- a/deployment/tests/workflow-policy.test.ps1
+++ b/deployment/tests/workflow-policy.test.ps1
@@ -1,0 +1,73 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$workflowPath = Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml'
+$remoteDeployPath = Join-Path $repositoryRoot 'deployment\remote-deploy.sh'
+$remoteRollbackPath = Join-Path $repositoryRoot 'deployment\remote-rollback.sh'
+
+function Assert-Match {
+    param([string]$Content, [string]$Pattern, [string]$Message)
+    if ($Content -notmatch $Pattern) { throw $Message }
+}
+
+function Assert-NoMatch {
+    param([string]$Content, [string]$Pattern, [string]$Message)
+    if ($Content -match $Pattern) { throw $Message }
+}
+
+foreach ($requiredPath in @($workflowPath, $remoteDeployPath, $remoteRollbackPath)) {
+    if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+        throw "Missing deployment file: $requiredPath"
+    }
+}
+
+$workflow = Get-Content -Raw -LiteralPath $workflowPath
+$remoteDeploy = Get-Content -Raw -LiteralPath $remoteDeployPath
+$remoteRollback = Get-Content -Raw -LiteralPath $remoteRollbackPath
+
+Assert-Match $workflow '(?m)^\s*workflow_dispatch:\s*$' 'Workflow must be manually dispatched.'
+Assert-NoMatch $workflow '(?m)^\s*(push|pull_request|pull_request_target|schedule):\s*$' 'Workflow must not deploy automatically.'
+Assert-Match $workflow '(?ms)^permissions:\s*\r?\n\s*contents:\s*read\s*$' 'Workflow permissions must be read-only.'
+Assert-Match $workflow '(?m)^\s*environment:\s*demo\s*$' 'Deploy job must use the demo environment.'
+Assert-Match $workflow '(?m)^\s*cancel-in-progress:\s*false\s*$' 'Deployments must not cancel one another.'
+Assert-Match $workflow 'actions/checkout@[a-f0-9]{40}' 'Checkout action must be commit-pinned.'
+Assert-Match $workflow 'StrictHostKeyChecking=yes' 'SSH must enforce host-key checking.'
+Assert-NoMatch $workflow 'StrictHostKeyChecking=no' 'SSH host-key checks must never be disabled.'
+Assert-Match $workflow 'GlobalKnownHostsFile=/dev/null' 'SSH must not consult global host keys.'
+Assert-NoMatch $workflow '(?i)ftp://|port\s*[:=]\s*21' 'Plain FTP is forbidden.'
+Assert-Match $workflow '\$\{\{\s*vars\.FTP_KNOWN_HOSTS\s*\}\}' 'Workflow must use verified known hosts.'
+Assert-Match $workflow '\[\[\s+"\$FTP_REMOTE_PATH"\s+==\s+''/home/www/chordsheets-demo''\s+\]\]' 'Workflow must pin the remote path.'
+Assert-NoMatch $workflow '\|\|\s*true' 'Rollback failures must not be ignored.'
+Assert-Match $workflow 'dokuwiki-chordsheets-demo\.zip' 'Workflow must deploy one ZIP artifact.'
+Assert-NoMatch $workflow 'dokuwiki-chordsheets-demo\.tgz' 'Workflow must not deploy a tarball.'
+Assert-Match $workflow 'mktemp.+\.upload\.\$GITHUB_SHA\.XXXXXX' 'Workflow must create a random server upload path.'
+Assert-Match $workflow 'rollback_state=' 'Workflow must inspect server state after rollback.'
+Assert-Match $workflow 'rollback_verification_failed' 'Workflow must verify a restored release after rollback.'
+
+$scpCount = [regex]::Matches($workflow, 'sshpass\s+-e\s+scp').Count
+if ($scpCount -ne 1) {
+    throw "Workflow must contain exactly one SCP upload, found $scpCount."
+}
+
+$secretReferences = [regex]::Matches($workflow, 'secrets\.([A-Z0-9_]+)') |
+    ForEach-Object { $_.Groups[1].Value } |
+    Sort-Object -Unique
+$expectedSecrets = @('FTP_PASSWORD', 'FTP_SERVER', 'FTP_USERNAME')
+if (($secretReferences -join ',') -ne ($expectedSecrets -join ',')) {
+    throw "Unexpected secret references: $($secretReferences -join ', ')"
+}
+
+Assert-Match $remoteDeploy 'unzip\s+-tqq' 'Remote deploy must CRC-test the ZIP.'
+Assert-Match $remoteDeploy 'unzip\s+-q\s+"\$archive"\s+-d\s+"\$staging"' 'Remote deploy must extract into fresh staging.'
+Assert-Match $remoteDeploy 'zipinfo\s+-l' 'Remote deploy must inspect ZIP entry types.'
+Assert-Match $remoteDeploy '\.deploy\.lock' 'Remote deploy must serialize server operations.'
+Assert-Match $remoteDeploy 'Persistent tree contains a link or special file' 'Remote deploy must reject unsafe persistent entries.'
+Assert-NoMatch $remoteDeploy 'tar\s+-[ctx].*zf' 'Remote deploy must not use tar for the release.'
+Assert-Match $remoteDeploy 'test ! -e|!\s+-e' 'Remote deploy must reject install.php.'
+Assert-Match $remoteRollback '\^\[a-f0-9\]\{40\}\$' 'Rollback must require a full Git SHA.'
+Assert-Match $remoteRollback '\.deploy\.lock' 'Rollback must use the deployment lock.'
+Assert-Match $remoteRollback 'lib/plugins/chordsheets/syntax\.php' 'Rollback must verify the plugin entry point.'
+Assert-NoMatch ($remoteDeploy + $remoteRollback) 'chmod\s+-R\s+777|rm\s+-rf\s+["'']?\$(root|remote_root)' 'Remote scripts contain an unsafe broad mutation.'
+
+Write-Host 'workflow-policy.test.ps1: PASS'

--- a/deployment/tests/zip-output.test.ps1
+++ b/deployment/tests/zip-output.test.ps1
@@ -1,0 +1,77 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$builder = Join-Path $repositoryRoot 'deployment\build-demo-zip.ps1'
+$temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('chordsheets-zip-test-' + [guid]::NewGuid().ToString('N'))
+$fixtureRoot = Join-Path $temporaryRoot 'dokuwiki-test'
+$fixtureArchive = Join-Path $temporaryRoot 'dokuwiki-test.tgz'
+$outputArchive = Join-Path $temporaryRoot 'demo-release.zip'
+$expandedOutput = Join-Path $temporaryRoot 'expanded'
+
+function Assert-True {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+try {
+    New-Item -ItemType Directory -Path (Join-Path $fixtureRoot 'inc') -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $fixtureRoot 'conf') -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $fixtureRoot 'data\pages') -Force | Out-Null
+
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'doku.php') -Value '<?php echo "fixture";'
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'install.php') -Value '<?php echo "installer";'
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'inc\init.php') -Value '<?php'
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'conf\dokuwiki.php') -Value '<?php'
+    Set-Content -LiteralPath (Join-Path $fixtureRoot 'data\pages\start.txt') -Value 'fixture'
+
+    Push-Location $temporaryRoot
+    try {
+        & tar -czf $fixtureArchive 'dokuwiki-test'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not create DokuWiki fixture archive.'
+        }
+    } finally {
+        Pop-Location
+    }
+
+    $fixtureSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $fixtureArchive).Hash.ToLowerInvariant()
+
+    & $builder `
+        -DokuWikiArchive $fixtureArchive `
+        -DokuWikiSha256 $fixtureSha256 `
+        -DokuWikiRootName 'dokuwiki-test' `
+        -OutputArchive $outputArchive `
+        -RepositoryRoot $repositoryRoot
+
+    Assert-True (Test-Path -LiteralPath $outputArchive -PathType Leaf) 'ZIP builder did not create an archive.'
+
+    Expand-Archive -LiteralPath $outputArchive -DestinationPath $expandedOutput
+    Assert-True (Test-Path -LiteralPath (Join-Path $expandedOutput 'doku.php') -PathType Leaf) 'ZIP is missing doku.php.'
+    Assert-True (Test-Path -LiteralPath (Join-Path $expandedOutput 'lib\plugins\chordsheets\syntax.php') -PathType Leaf) 'ZIP is missing the plugin.'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $expandedOutput 'install.php'))) 'ZIP contains install.php.'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $expandedOutput 'data'))) 'ZIP contains mutable data.'
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($outputArchive)
+    try {
+        $entryNames = @($zip.Entries | ForEach-Object { $_.FullName })
+    } finally {
+        $zip.Dispose()
+    }
+
+    Assert-True ($entryNames -contains 'doku.php') 'ZIP entry list is missing doku.php.'
+    Assert-True (-not ($entryNames | Where-Object { $_.StartsWith('/') -or $_.Contains('../') })) 'ZIP contains an unsafe path.'
+
+    Write-Host 'zip-output.test.ps1: PASS'
+} finally {
+    if (Test-Path -LiteralPath $temporaryRoot) {
+        Remove-Item -LiteralPath $temporaryRoot -Recurse -Force
+    }
+}

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,73 @@
+# Local DokuWiki test environment
+
+This repository contains a local DokuWiki environment for manual plugin testing.
+It uses the official, version-pinned DokuWiki image and mounts the runtime files
+from this repository read-only as the `chordsheets` plugin.
+
+## Start
+
+From the repository root:
+
+```powershell
+docker compose up --detach --wait
+```
+
+Open <http://127.0.0.1:8080/doku.php?id=start>. The preconfigured start page
+contains a guitar sheet and a sheet prepared for ukulele support.
+
+Compose derives its project and volume names from the checkout directory. If
+you run multiple checkouts with the same directory name, set a unique project
+name before running any Compose command:
+
+```powershell
+$env:COMPOSE_PROJECT_NAME = 'dokuwiki-chordsheets-my-branch'
+```
+
+```bash
+export COMPOSE_PROJECT_NAME=dokuwiki-chordsheets-my-branch
+```
+
+Keep using the same value when stopping or resetting that checkout.
+
+Wiki data is stored in the `dokuwiki-data` Docker volume, while plugin code is
+read directly from the working tree. The seeded configuration and start page
+are refreshed on every `docker compose up`; other pages remain in the volume.
+Hard-refresh the browser if DokuWiki has cached a changed JavaScript or CSS
+asset.
+
+## Smoke test
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\docker\smoke-test.ps1
+```
+
+On Linux with PowerShell installed:
+
+```bash
+pwsh -NoProfile -File ./docker/smoke-test.ps1
+```
+
+Use a different host port when 8080 is occupied:
+
+```powershell
+.\docker\smoke-test.ps1 -Port 8081
+```
+
+## Stop and reset
+
+Stop the environment without losing its data:
+
+```powershell
+docker compose down
+```
+
+To deliberately reset all local wiki configuration and pages:
+
+```powershell
+docker compose down --volumes
+```
+
+The last command permanently deletes this checkout's local `dokuwiki-data`
+volume. Do not update or remove the `chordsheets` plugin through DokuWiki's
+Extension Manager; the plugin files are read-only bind mounts from this
+repository.

--- a/docker/dokuwiki/local.php
+++ b/docker/dokuwiki/local.php
@@ -1,0 +1,6 @@
+<?php
+
+$conf['title'] = 'DokuWiki Chordsheets Test';
+$conf['lang'] = 'en';
+$conf['license'] = 'cc-by-sa';
+$conf['useacl'] = 0;

--- a/docker/dokuwiki/start.txt
+++ b/docker/dokuwiki/start.txt
@@ -1,0 +1,29 @@
+====== DokuWiki Chordsheets Test ======
+
+This local wiki loads the ''chordsheets'' plugin directly from the repository.
+
+===== Guitar =====
+
+<chordSheet 0>
+[Intro]
+Am    F/C    C    G
+
+[Verse]
+C
+This is the guitar test sheet
+G
+Hover the highlighted chords
+</chordSheet>
+
+===== Ukulele feature test =====
+
+The following sheet is ready for Issue #7 / PR #8. Until ukulele support is implemented, it will still show guitar diagrams.
+
+<chordSheet 2 instrument="ukulele">
+[Intro]
+Am    G    C    F
+
+[Verse]
+C
+This sheet also verifies transposition with an instrument attribute
+</chordSheet>

--- a/docker/smoke-test.ps1
+++ b/docker/smoke-test.ps1
@@ -1,0 +1,103 @@
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 65535)]
+    [int]$Port = 8080,
+
+    [switch]$SkipStart
+)
+
+$ErrorActionPreference = 'Stop'
+$projectRoot = Split-Path -Parent $PSScriptRoot
+$composeFile = Join-Path $projectRoot 'compose.yaml'
+$previousPort = $env:DOKUWIKI_PORT
+
+function Invoke-Compose {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    & docker compose --file $composeFile @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "docker compose $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
+}
+
+try {
+    if (-not (Test-Path -LiteralPath $composeFile)) {
+        throw "Compose file not found: $composeFile"
+    }
+
+    $env:DOKUWIKI_PORT = [string]$Port
+    Invoke-Compose -Arguments @('config', '--quiet')
+
+    if (-not $SkipStart) {
+        Invoke-Compose -Arguments @('up', '--detach', '--wait')
+    }
+
+    $baseUrl = "http://127.0.0.1:$Port"
+    $page = Invoke-WebRequest -Uri "$baseUrl/doku.php?id=start" -UseBasicParsing
+
+    if ($page.StatusCode -ne 200) {
+        throw "DokuWiki returned HTTP $($page.StatusCode)."
+    }
+
+    foreach ($marker in @('DokuWiki Chordsheets Test', 'song-with-chords')) {
+        if ($page.Content -notmatch [regex]::Escape($marker)) {
+            throw "Expected marker '$marker' was not found in the rendered start page."
+        }
+    }
+
+    if ([regex]::Matches($page.Content, 'song-with-chords').Count -lt 2) {
+        throw 'The rendered start page does not contain both test chord sheets.'
+    }
+
+    $rawPage = Invoke-WebRequest -Uri "$baseUrl/doku.php?id=start&do=export_raw" -UseBasicParsing
+    if ($rawPage.Content -notmatch [regex]::Escape('<chordSheet 2 instrument="ukulele">')) {
+        throw 'The ukulele/transposition regression fixture is missing from the start page.'
+    }
+
+    $asset = Invoke-WebRequest -Uri "$baseUrl/lib/plugins/chordsheets/script.js" -UseBasicParsing
+    if ($asset.StatusCode -ne 200 -or $asset.Content -notmatch 'runSongHighlighter') {
+        throw 'The bind-mounted chordsheets plugin asset is not available.'
+    }
+
+    Invoke-Compose -Arguments @(
+        'exec',
+        '--no-TTY',
+        'dokuwiki',
+        'test',
+        '-f',
+        '/storage/lib/plugins/chordsheets/plugin.info.txt'
+    )
+
+    Invoke-Compose -Arguments @(
+        'exec',
+        '--no-TTY',
+        'dokuwiki',
+        'test',
+        '!',
+        '-w',
+        '/storage/lib/plugins/chordsheets/script.js'
+    )
+
+    Invoke-Compose -Arguments @(
+        'exec',
+        '--no-TTY',
+        'dokuwiki',
+        'test',
+        '!',
+        '-e',
+        '/storage/lib/plugins/chordsheets/README.md'
+    )
+
+    Write-Host "Smoke test passed: $baseUrl/doku.php?id=start"
+}
+finally {
+    if ($null -eq $previousPort) {
+        Remove-Item Env:DOKUWIKI_PORT -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:DOKUWIKI_PORT = $previousPort
+    }
+}


### PR DESCRIPTION
## Summary
- add a pinned local DokuWiki Docker setup with smoke tests
- build one verified ZIP release and extract it server-side on Webgo
- add strict SSH host-key pinning, atomic releases, rollback, and fail-closed verification
- persist DokuWiki data/configuration without requiring a database

## Test plan
- artifact-build.test.ps1
- zip-output.test.ps1
- workflow-policy.test.ps1
- fail-closed-rollback.test.ps1
- Docker remote deploy/rollback integration
- local DokuWiki smoke test
- actionlint and PHP syntax check

All checks passed locally; final code and security reviews found no remaining medium/P0-P2 issues.