### PR TITLE
Support canonical Webgo deployment paths

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -61,6 +61,7 @@ jobs:
           ./deployment/tests/zip-output.test.ps1
           ./deployment/tests/workflow-policy.test.ps1
           ./deployment/tests/fail-closed-rollback.test.ps1
+          ./deployment/tests/canonical-root.test.ps1
 
       - name: Simulate remote ZIP release and rollback
         shell: bash
@@ -137,7 +138,7 @@ jobs:
 
           remote_archive=$(sshpass -e ssh "${ssh_options[@]}" \
             "$FTP_USERNAME@$FTP_SERVER" \
-            "set -euo pipefail; umask 0077; mkdir -p '$FTP_REMOTE_PATH'; test -d '$FTP_REMOTE_PATH'; test ! -L '$FTP_REMOTE_PATH'; test \"\$(realpath -e '$FTP_REMOTE_PATH')\" = '$FTP_REMOTE_PATH'; mkdir -p '$FTP_REMOTE_PATH/uploads'; test -d '$FTP_REMOTE_PATH/uploads'; test ! -L '$FTP_REMOTE_PATH/uploads'; test \"\$(realpath -e '$FTP_REMOTE_PATH/uploads')\" = '$FTP_REMOTE_PATH/uploads'; chmod 0700 '$FTP_REMOTE_PATH/uploads'; mktemp '$FTP_REMOTE_PATH/uploads/.upload.$GITHUB_SHA.XXXXXX'")
+            "set -euo pipefail; umask 0077; canonical_parent=\$(realpath -e '/home/www'); mkdir -p '$FTP_REMOTE_PATH'; test -d '$FTP_REMOTE_PATH'; test ! -L '$FTP_REMOTE_PATH'; canonical_remote_root=\$(realpath -e '$FTP_REMOTE_PATH'); test \"\$canonical_remote_root\" = \"\$canonical_parent/chordsheets-demo\"; mkdir -p '$FTP_REMOTE_PATH/uploads'; test -d '$FTP_REMOTE_PATH/uploads'; test ! -L '$FTP_REMOTE_PATH/uploads'; canonical_uploads=\$(realpath -e '$FTP_REMOTE_PATH/uploads'); test \"\$canonical_uploads\" = \"\$canonical_remote_root/uploads\"; chmod 0700 '$FTP_REMOTE_PATH/uploads'; mktemp '$FTP_REMOTE_PATH/uploads/.upload.$GITHUB_SHA.XXXXXX'")
           [[ "$remote_archive" =~ ^/home/www/chordsheets-demo/uploads/\.upload\.$GITHUB_SHA\.[A-Za-z0-9]{6}$ ]]
           upload_name=${remote_archive##*/}
 

--- a/deployment/remote-deactivate.sh
+++ b/deployment/remote-deactivate.sh
@@ -16,7 +16,9 @@ expected_sha=${2:-}
 
 test -d "$remote_root"
 test ! -L "$remote_root"
-test "$(realpath -e "$remote_root")" = "$remote_root"
+canonical_parent=$(realpath -e /home/www)
+canonical_root=$(realpath -e "$remote_root")
+test "$canonical_root" = "$canonical_parent/${remote_root##*/}"
 
 lock="$remote_root/.deploy.lock"
 mkdir "$lock" 2>/dev/null || {

--- a/deployment/remote-deploy.sh
+++ b/deployment/remote-deploy.sh
@@ -17,7 +17,10 @@ for command_name in unzip zipinfo realpath sha256sum stat php; do
 done
 
 mkdir -p "$root"
-[[ "$(realpath -e "$root")" == "$root" ]] || { echo 'Remote root resolves through a symlink.' >&2; exit 2; }
+[[ -d "$root" && ! -L "$root" ]] || { echo 'Remote root must be a real directory.' >&2; exit 2; }
+canonical_parent=$(realpath -e /home/www)
+canonical_root=$(realpath -e "$root")
+[[ "$canonical_root" == "$canonical_parent/${root##*/}" ]] || { echo 'Remote root resolves through a symlink.' >&2; exit 2; }
 
 uploads="$root/uploads"
 releases="$root/releases"

--- a/deployment/remote-rollback.sh
+++ b/deployment/remote-rollback.sh
@@ -16,7 +16,10 @@ if [[ ! "$failed_sha" =~ ^[a-f0-9]{40}$ ]]; then
 fi
 
 test -d "$remote_root"
-if [[ "$(realpath -e "$remote_root")" != "$remote_root" ]]; then
+test ! -L "$remote_root"
+canonical_parent=$(realpath -e /home/www)
+canonical_root=$(realpath -e "$remote_root")
+if [[ "$canonical_root" != "$canonical_parent/${remote_root##*/}" ]]; then
   echo "Remote root must not resolve through a symlink." >&2
   exit 2
 fi

--- a/deployment/tests/canonical-root.test.ps1
+++ b/deployment/tests/canonical-root.test.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$workflow = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml')
+$scripts = @(
+    'deployment\remote-deploy.sh',
+    'deployment\remote-rollback.sh',
+    'deployment\remote-deactivate.sh'
+) | ForEach-Object {
+    Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot $_)
+}
+
+if ($workflow -notmatch "realpath -e '/home/www'") {
+    throw 'Upload preflight must canonicalize the Webgo parent directory.'
+}
+if ($workflow -notmatch 'canonical_remote_root') {
+    throw 'Upload preflight must compare the canonical direct-child target.'
+}
+
+foreach ($script in $scripts) {
+    if ($script -notmatch 'canonical_parent=.*realpath -e /home/www') {
+        throw 'Remote operation must canonicalize the Webgo parent directory.'
+    }
+    if ($script -notmatch 'canonical_root') {
+        throw 'Remote operation must compare the canonical direct-child target.'
+    }
+    if ($script -notmatch '!\s+-L\s+"\$(root|remote_root)"') {
+        throw 'Remote operation must reject a symlink at the deployment root.'
+    }
+}
+
+Write-Host 'canonical-root.test.ps1: PASS'


### PR DESCRIPTION
Webgo canonicalizes the /home/www parent internally. This keeps strict direct-child and no-symlink checks while comparing against the canonical parent, and adds a regression test. Local policy, actionlint, security review, and full ZIP deploy/rollback integration are green.