### PR TITLE
Extract and harden remote upload preflight

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -63,6 +63,8 @@ jobs:
           ./deployment/tests/fail-closed-rollback.test.ps1
           ./deployment/tests/canonical-root.test.ps1
           ./deployment/tests/remote-upload-name.test.ps1
+          ./deployment/tests/remote-upload-preflight-policy.test.ps1
+          ./deployment/tests/upload-cleanup.test.ps1
 
       - name: Simulate remote ZIP release and rollback
         shell: bash
@@ -77,7 +79,8 @@ jobs:
             -lc '
               apt-get update -qq
               DEBIAN_FRONTEND=noninteractive apt-get install -y -qq unzip >/dev/null
-              /repo/deployment/tests/remote-deploy.integration.sh /input/release.zip
+              bash /repo/deployment/tests/remote-upload-preflight.integration.sh /repo/deployment/remote-upload-preflight.sh
+              bash /repo/deployment/tests/remote-deploy.integration.sh /input/release.zip
             '
 
       - name: Run local DokuWiki smoke test
@@ -137,12 +140,30 @@ jobs:
           release_archive="$RUNNER_TEMP/dokuwiki-chordsheets-demo.zip"
           archive_sha256=$(sha256sum "$release_archive" | awk '{print $1}')
 
-          remote_result=$(sshpass -e ssh "${ssh_options[@]}" \
+          if ! remote_result=$(sshpass -e ssh "${ssh_options[@]}" \
             "$FTP_USERNAME@$FTP_SERVER" \
-            "set -euo pipefail; umask 0077; canonical_parent=\$(realpath -e '/home/www'); mkdir -p '$FTP_REMOTE_PATH'; test -d '$FTP_REMOTE_PATH'; test ! -L '$FTP_REMOTE_PATH'; canonical_remote_root=\$(realpath -e '$FTP_REMOTE_PATH'); test \"\$canonical_remote_root\" = \"\$canonical_parent/chordsheets-demo\"; mkdir -p '$FTP_REMOTE_PATH/uploads'; test -d '$FTP_REMOTE_PATH/uploads'; test ! -L '$FTP_REMOTE_PATH/uploads'; canonical_uploads=\$(realpath -e '$FTP_REMOTE_PATH/uploads'); test \"\$canonical_uploads\" = \"\$canonical_remote_root/uploads\"; chmod 0700 '$FTP_REMOTE_PATH/uploads'; upload_file=\$(mktemp '$FTP_REMOTE_PATH/uploads/.upload.$GITHUB_SHA.XXXXXX'); printf 'UPLOAD:%s' \"\${upload_file##*/}\"")
+            "bash -s -- '$FTP_REMOTE_PATH' '$GITHUB_SHA'" \
+            < deployment/remote-upload-preflight.sh); then
+            echo 'Remote upload preflight failed.' >&2
+            exit 1
+          fi
           [[ "$remote_result" =~ ^UPLOAD:(\.upload\.$GITHUB_SHA\.[A-Za-z0-9]{6})$ ]]
           upload_name=${BASH_REMATCH[1]}
           remote_archive="$FTP_REMOTE_PATH/uploads/$upload_name"
+          remote_upload_pending=1
+
+          cleanup_remote_upload() {
+            if [[ "$remote_upload_pending" -eq 0 ]]; then
+              return
+            fi
+
+            if ! sshpass -e ssh "${ssh_options[@]}" \
+              "$FTP_USERNAME@$FTP_SERVER" \
+              "rm -f -- '$remote_archive'"; then
+              echo 'Warning: failed to remove pending remote upload.' >&2
+            fi
+          }
+          trap cleanup_remote_upload EXIT
 
           sshpass -e scp \
             -P "$FTP_PORT" \
@@ -160,6 +181,8 @@ jobs:
             "bash -s -- '$FTP_REMOTE_PATH' '$GITHUB_SHA' '$archive_sha256' '$upload_name'" \
             < deployment/remote-deploy.sh
 
+          remote_upload_pending=0
+          trap - EXIT
           smoke_failed=0
           curl --fail --silent --show-error \
             "$DEMO_URL/doku.php?id=start" \

--- a/deployment/remote-deploy.sh
+++ b/deployment/remote-deploy.sh
@@ -37,6 +37,11 @@ mkdir -p "$uploads" "$releases" "$shared"
 chmod 0700 "$uploads" "$shared"
 
 [[ -f "$archive" && ! -L "$archive" ]] || { echo 'Uploaded ZIP is missing or unsafe.' >&2; exit 3; }
+cleanup_archive() {
+  rm -f -- "$archive"
+}
+trap cleanup_archive EXIT
+
 archive_bytes=$(stat -c '%s' "$archive")
 (( archive_bytes > 0 && archive_bytes <= 67108864 )) || { echo 'ZIP size is outside the allowed range.' >&2; exit 3; }
 actual_hash=$(sha256sum "$archive" | awk '{print $1}')
@@ -75,6 +80,7 @@ unzip -Z1 "$archive" | awk '
 mkdir "$lock" 2>/dev/null || { echo 'Another deployment is active.' >&2; exit 5; }
 locked=1
 cleanup() {
+  rm -f -- "$archive"
   [[ ! -e "$staging" && ! -L "$staging" ]] || rm -rf -- "$staging"
   if [[ "${locked:-0}" -eq 1 && -d "$lock" && ! -L "$lock" ]]; then
     rmdir "$lock"

--- a/deployment/remote-upload-preflight.sh
+++ b/deployment/remote-upload-preflight.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 0077
+
+fail() {
+    printf 'Remote upload preflight failed: %s\n' "$1" >&2
+    exit 1
+}
+
+if (( $# != 2 )); then
+    fail 'expected deployment root and commit SHA arguments'
+fi
+
+root=$1
+sha=$2
+
+if [[ ! "$root" =~ ^/home/www/([A-Za-z0-9][A-Za-z0-9._-]*)$ ]]; then
+    fail 'deployment root must be a direct safe child of /home/www'
+fi
+root_basename=${BASH_REMATCH[1]}
+
+if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+    fail 'commit SHA must contain exactly 40 lowercase hexadecimal characters'
+fi
+
+command -v realpath >/dev/null 2>&1 || fail 'required command realpath is unavailable'
+command -v mktemp >/dev/null 2>&1 || fail 'required command mktemp is unavailable'
+command -v find >/dev/null 2>&1 || fail 'required command find is unavailable'
+
+mkdir -p -- "$root" || fail 'could not create deployment root'
+test -d "$root" || fail 'deployment root is not a directory'
+test ! -L "$root" || fail 'deployment root must not be a symbolic link'
+
+if ! canonical_parent=$(realpath -e /home/www); then
+    fail 'could not resolve /home/www'
+fi
+if ! canonical_root=$(realpath -e -- "$root"); then
+    fail 'could not resolve deployment root'
+fi
+if [[ "$canonical_root" != "$canonical_parent/$root_basename" ]]; then
+    fail 'deployment root resolves outside its expected location'
+fi
+
+uploads="$root/uploads"
+mkdir -p -- "$uploads" || fail 'could not create uploads directory'
+test -d "$uploads" || fail 'uploads path is not a directory'
+test ! -L "$uploads" || fail 'uploads directory must not be a symbolic link'
+
+if ! canonical_uploads=$(realpath -e -- "$uploads"); then
+    fail 'could not resolve uploads directory'
+fi
+if [[ "$canonical_uploads" != "$canonical_root/uploads" ]]; then
+    fail 'uploads directory resolves outside the deployment root'
+fi
+
+chmod 0700 -- "$uploads" || fail 'could not secure uploads directory permissions'
+
+if ! find "$uploads" -maxdepth 1 -type f -mmin +45 -print0 |
+    while IFS= read -r -d '' stale_upload; do
+        stale_upload_basename=${stale_upload##*/}
+        if [[ "$stale_upload_basename" =~ ^\.upload\.[0-9a-f]{40}\.[A-Za-z0-9]{6}$ ]] &&
+            [[ -f "$stale_upload" ]] && [[ ! -L "$stale_upload" ]]; then
+            rm -f -- "$stale_upload" || exit 1
+        fi
+    done
+then
+    fail 'could not remove stale upload files'
+fi
+
+if ! upload_file=$(mktemp -- "$uploads/.upload.$sha.XXXXXX"); then
+    fail 'could not create upload file'
+fi
+readonly upload_file
+
+cleanup_upload_file() {
+    if [[ -f "$upload_file" ]] && [[ ! -L "$upload_file" ]]; then
+        rm -f -- "$upload_file"
+    fi
+}
+trap cleanup_upload_file EXIT
+
+upload_basename=${upload_file##*/}
+
+if [[ "$upload_file" != "$uploads/$upload_basename" ]] ||
+    [[ ! "$upload_basename" =~ ^\.upload\.${sha}\.[A-Za-z0-9]{6}$ ]]; then
+    fail 'generated upload filename does not match the required format'
+fi
+
+trap - EXIT
+printf 'UPLOAD:%s' "$upload_basename"

--- a/deployment/tests/canonical-root.test.ps1
+++ b/deployment/tests/canonical-root.test.ps1
@@ -4,6 +4,7 @@ Set-StrictMode -Version Latest
 $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $workflow = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml')
 $scripts = @(
+    'deployment\remote-upload-preflight.sh',
     'deployment\remote-deploy.sh',
     'deployment\remote-rollback.sh',
     'deployment\remote-deactivate.sh'
@@ -11,11 +12,8 @@ $scripts = @(
     Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot $_)
 }
 
-if ($workflow -notmatch "realpath -e '/home/www'") {
-    throw 'Upload preflight must canonicalize the Webgo parent directory.'
-}
-if ($workflow -notmatch 'canonical_remote_root') {
-    throw 'Upload preflight must compare the canonical direct-child target.'
+if ($workflow -notmatch 'deployment/remote-upload-preflight\.sh') {
+    throw 'Workflow must invoke the remote upload preflight script.'
 }
 
 foreach ($script in $scripts) {

--- a/deployment/tests/fail-closed-rollback.test.ps1
+++ b/deployment/tests/fail-closed-rollback.test.ps1
@@ -3,18 +3,21 @@ Set-StrictMode -Version Latest
 
 $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $workflowPath = Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml'
+$preflightPath = Join-Path $repositoryRoot 'deployment\remote-upload-preflight.sh'
 $deactivatePath = Join-Path $repositoryRoot 'deployment\remote-deactivate.sh'
 
-if (-not (Test-Path -LiteralPath $deactivatePath -PathType Leaf)) {
-    throw 'Missing fail-closed remote deactivation script.'
+foreach ($requiredPath in @($preflightPath, $deactivatePath)) {
+    if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+        throw "Missing fail-closed deployment script: $requiredPath"
+    }
 }
 
 $workflow = Get-Content -Raw -LiteralPath $workflowPath
+$preflight = Get-Content -Raw -LiteralPath $preflightPath
 $deactivate = Get-Content -Raw -LiteralPath $deactivatePath
 
 foreach ($pattern in @(
-    'realpath -e ''\$FTP_REMOTE_PATH''',
-    'realpath -e ''\$FTP_REMOTE_PATH/uploads''',
+    'deployment/remote-upload-preflight\.sh',
     'rollback_verification_failed',
     '403'' \|\| \"\$status\" == ''404',
     'deployment/remote-deactivate\.sh',
@@ -22,6 +25,15 @@ foreach ($pattern in @(
 )) {
     if ($workflow -notmatch $pattern) {
         throw "Workflow is missing fail-closed rollback protection: $pattern"
+    }
+}
+
+foreach ($pattern in @(
+    'canonical_root=.*realpath -e -- "\$root"',
+    'canonical_uploads=.*realpath -e -- "\$uploads"'
+)) {
+    if ($preflight -notmatch $pattern) {
+        throw "Remote preflight is missing fail-closed path protection: $pattern"
     }
 }
 

--- a/deployment/tests/remote-upload-name.test.ps1
+++ b/deployment/tests/remote-upload-name.test.ps1
@@ -3,9 +3,10 @@ Set-StrictMode -Version Latest
 
 $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $workflow = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml')
+$preflight = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot 'deployment\remote-upload-preflight.sh')
 
 foreach ($pattern in @(
-    'printf ''UPLOAD:%s''',
+    'deployment/remote-upload-preflight\.sh',
     '\^UPLOAD:\(\\\.upload\\\.\$GITHUB_SHA',
     'BASH_REMATCH\[1\]',
     'remote_archive="\$FTP_REMOTE_PATH/uploads/\$upload_name"'
@@ -13,6 +14,10 @@ foreach ($pattern in @(
     if ($workflow -notmatch $pattern) {
         throw "Workflow is missing the validated remote upload-name protocol: $pattern"
     }
+}
+
+if ($preflight -notmatch 'printf ''UPLOAD:%s''') {
+    throw 'Remote preflight must emit only the upload-name protocol response.'
 }
 
 Write-Host 'remote-upload-name.test.ps1: PASS'

--- a/deployment/tests/remote-upload-preflight-policy.test.ps1
+++ b/deployment/tests/remote-upload-preflight-policy.test.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$workflow = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml')
+$preflightPath = Join-Path $repositoryRoot 'deployment\remote-upload-preflight.sh'
+
+if (-not (Test-Path -LiteralPath $preflightPath -PathType Leaf)) {
+    throw 'Missing remote upload preflight script.'
+}
+
+$preflight = Get-Content -Raw -LiteralPath $preflightPath
+
+foreach ($pattern in @(
+    'deployment/remote-upload-preflight\.sh',
+    'Remote upload preflight failed',
+    '\^UPLOAD:\(\\\.upload\\\.\$GITHUB_SHA'
+)) {
+    if ($workflow -notmatch $pattern) {
+        throw "Workflow is missing the remote preflight contract: $pattern"
+    }
+}
+
+foreach ($pattern in @(
+    '\^/home/www/',
+    'canonical_parent=.*realpath -e /home/www',
+    'canonical_root',
+    'test ! -L "\$root"',
+    'mktemp',
+    'printf ''UPLOAD:%s'''
+)) {
+    if ($preflight -notmatch $pattern) {
+        throw "Remote preflight is missing a safety invariant: $pattern"
+    }
+}
+
+Write-Host 'remote-upload-preflight-policy.test.ps1: PASS'

--- a/deployment/tests/remote-upload-preflight.integration.sh
+++ b/deployment/tests/remote-upload-preflight.integration.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+preflight_script=${1:-}
+test -f "$preflight_script"
+
+root=/home/www/chordsheets-preflight
+sha=7777777777777777777777777777777777777777
+old_sha=6666666666666666666666666666666666666666
+fresh_sha=5555555555555555555555555555555555555555
+symlink_sha=9999999999999999999999999999999999999999
+stale_upload="$root/uploads/.upload.$old_sha.AbC123"
+fresh_upload="$root/uploads/.upload.$fresh_sha.FrE123"
+foreign_file="$root/uploads/keep-me.txt"
+upload_symlink="$root/uploads/.upload.$symlink_sha.SyM123"
+
+cleanup_test_root() {
+  rm -rf -- "$root"
+}
+trap cleanup_test_root EXIT
+
+rm -rf -- "$root"
+mkdir -p -- "$root/uploads"
+printf 'stale\n' > "$stale_upload"
+touch -d '46 minutes ago' "$stale_upload"
+printf 'fresh\n' > "$fresh_upload"
+printf 'foreign\n' > "$foreign_file"
+ln -s "${foreign_file##*/}" "$upload_symlink"
+
+result=$(bash "$preflight_script" "$root" "$sha")
+
+[[ "$result" =~ ^UPLOAD:(\.upload\.$sha\.[A-Za-z0-9]{6})$ ]]
+upload_name=${BASH_REMATCH[1]}
+test ! -e "$stale_upload"
+test -f "$fresh_upload"
+test -f "$foreign_file"
+test -L "$upload_symlink"
+test -f "$root/uploads/$upload_name"
+test ! -L "$root"
+test ! -L "$root/uploads"
+
+matching_upload_count=0
+new_upload_count=0
+while IFS= read -r -d '' candidate; do
+  candidate_basename=${candidate##*/}
+  if [[ "$candidate_basename" =~ ^\.upload\.[0-9a-f]{40}\.[A-Za-z0-9]{6}$ ]]; then
+    ((matching_upload_count += 1))
+    if [[ "$candidate_basename" == "$upload_name" ]]; then
+      ((new_upload_count += 1))
+    else
+      [[ "$candidate_basename" == "${fresh_upload##*/}" ]]
+    fi
+  fi
+done < <(find "$root/uploads" -maxdepth 1 -type f -print0)
+((matching_upload_count == 2))
+((new_upload_count == 1))
+
+rm -rf -- "$root"
+ln -s /tmp "$root"
+if bash "$preflight_script" "$root" 8888888888888888888888888888888888888888; then
+  echo 'Preflight accepted a symlink deployment root.' >&2
+  exit 1
+fi
+
+echo 'remote-upload-preflight.integration.sh: PASS'

--- a/deployment/tests/upload-cleanup.test.ps1
+++ b/deployment/tests/upload-cleanup.test.ps1
@@ -1,0 +1,42 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$workflow = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml')
+$preflight = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot 'deployment\remote-upload-preflight.sh')
+$deploy = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot 'deployment\remote-deploy.sh')
+
+foreach ($pattern in @(
+    'cleanup_remote_upload',
+    'remote_upload_pending',
+    'trap cleanup_remote_upload EXIT',
+    'trap - EXIT'
+)) {
+    if ($workflow -notmatch $pattern) {
+        throw "Workflow is missing remote upload cleanup: $pattern"
+    }
+}
+
+foreach ($content in @($preflight, $deploy)) {
+    if ($content -notmatch 'trap \w+ EXIT') {
+        throw 'Remote script must install an EXIT cleanup trap.'
+    }
+    if ($content -notmatch 'rm -f -- "\$(upload_file|archive)"') {
+        throw 'Remote script must remove its exact upload file on failure.'
+    }
+}
+
+$staleUploadNameRegex = [regex]::Escape('^\.upload\.[0-9a-f]{40}\.[A-Za-z0-9]{6}$')
+foreach ($pattern in @(
+    'find "\$uploads" -maxdepth 1 -type f -mmin \+45 -print0',
+    'stale_upload_basename=\$\{stale_upload##\*/\}',
+    $staleUploadNameRegex,
+    '! -L "\$stale_upload"',
+    'rm -f -- "\$stale_upload"'
+)) {
+    if ($preflight -notmatch $pattern) {
+        throw "Remote preflight is missing stale upload cleanup protection: $pattern"
+    }
+}
+
+Write-Host 'upload-cleanup.test.ps1: PASS'

--- a/deployment/tests/workflow-policy.test.ps1
+++ b/deployment/tests/workflow-policy.test.ps1
@@ -3,6 +3,7 @@ Set-StrictMode -Version Latest
 
 $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $workflowPath = Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml'
+$remotePreflightPath = Join-Path $repositoryRoot 'deployment\remote-upload-preflight.sh'
 $remoteDeployPath = Join-Path $repositoryRoot 'deployment\remote-deploy.sh'
 $remoteRollbackPath = Join-Path $repositoryRoot 'deployment\remote-rollback.sh'
 
@@ -16,13 +17,14 @@ function Assert-NoMatch {
     if ($Content -match $Pattern) { throw $Message }
 }
 
-foreach ($requiredPath in @($workflowPath, $remoteDeployPath, $remoteRollbackPath)) {
+foreach ($requiredPath in @($workflowPath, $remotePreflightPath, $remoteDeployPath, $remoteRollbackPath)) {
     if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
         throw "Missing deployment file: $requiredPath"
     }
 }
 
 $workflow = Get-Content -Raw -LiteralPath $workflowPath
+$remotePreflight = Get-Content -Raw -LiteralPath $remotePreflightPath
 $remoteDeploy = Get-Content -Raw -LiteralPath $remoteDeployPath
 $remoteRollback = Get-Content -Raw -LiteralPath $remoteRollbackPath
 
@@ -41,7 +43,8 @@ Assert-Match $workflow '\[\[\s+"\$FTP_REMOTE_PATH"\s+==\s+''/home/www/chordsheet
 Assert-NoMatch $workflow '\|\|\s*true' 'Rollback failures must not be ignored.'
 Assert-Match $workflow 'dokuwiki-chordsheets-demo\.zip' 'Workflow must deploy one ZIP artifact.'
 Assert-NoMatch $workflow 'dokuwiki-chordsheets-demo\.tgz' 'Workflow must not deploy a tarball.'
-Assert-Match $workflow 'mktemp.+\.upload\.\$GITHUB_SHA\.XXXXXX' 'Workflow must create a random server upload path.'
+Assert-Match $workflow 'deployment/remote-upload-preflight\.sh' 'Workflow must invoke the remote upload preflight script.'
+Assert-Match $remotePreflight 'mktemp.+\.upload\.\$sha\.XXXXXX' 'Remote preflight must create a random server upload path.'
 Assert-Match $workflow 'rollback_state=' 'Workflow must inspect server state after rollback.'
 Assert-Match $workflow 'rollback_verification_failed' 'Workflow must verify a restored release after rollback.'
 


### PR DESCRIPTION
## Summary
- extract the Webgo SSH upload preflight into a tested script
- upload one ZIP archive and validate the exact remote temporary filename
- clean up failed and stale uploads without touching unrelated files
- preserve atomic deployment and rollback behavior
- surface a clear error when the remote preflight fails

## Verification
- PowerShell policy and rollback tests
- Docker preflight and remote-deploy integration tests using the full DokuWiki ZIP
- actionlint
- security and code review