### PR TITLE
Diagnose Webgo remote shell capability

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -64,6 +64,7 @@ jobs:
           ./deployment/tests/canonical-root.test.ps1
           ./deployment/tests/remote-upload-name.test.ps1
           ./deployment/tests/remote-upload-preflight-policy.test.ps1
+          ./deployment/tests/remote-shell-policy.test.ps1
           ./deployment/tests/upload-cleanup.test.ps1
 
       - name: Simulate remote ZIP release and rollback
@@ -139,6 +140,17 @@ jobs:
 
           release_archive="$RUNNER_TEMP/dokuwiki-chordsheets-demo.zip"
           archive_sha256=$(sha256sum "$release_archive" | awk '{print $1}')
+
+          if ! remote_shell_probe=$(sshpass -e ssh "${ssh_options[@]}" \
+            "$FTP_USERNAME@$FTP_SERVER" \
+            "command -v bash >/dev/null 2>&1 && printf REMOTE_SHELL_OK"); then
+            echo 'SSH account does not permit remote Bash command execution; use a Webgo SSH-enabled account rather than an FTP-only account.' >&2
+            exit 1
+          fi
+          if [[ "$remote_shell_probe" != 'REMOTE_SHELL_OK' ]]; then
+            echo 'Remote Bash capability probe returned an unexpected response.' >&2
+            exit 1
+          fi
 
           if ! remote_result=$(sshpass -e ssh "${ssh_options[@]}" \
             "$FTP_USERNAME@$FTP_SERVER" \

--- a/deployment/tests/remote-shell-policy.test.ps1
+++ b/deployment/tests/remote-shell-policy.test.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$workflowPath = Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml'
+$workflow = Get-Content -Raw -LiteralPath $workflowPath
+
+if ($workflow -notmatch 'REMOTE_SHELL_OK') {
+    throw 'Workflow must verify remote shell command execution before deployment.'
+}
+
+if ($workflow -notmatch 'SSH account does not permit remote Bash command execution') {
+    throw 'Workflow must explain a missing remote shell capability.'
+}
+
+Write-Host 'remote-shell-policy.test.ps1: PASS'


### PR DESCRIPTION
## Summary
- probe remote Bash command execution before starting the ZIP upload
- report clearly when the configured account is FTP/SFTP-only
- add a policy test for the diagnostic guard

## Verification
- remote-shell-policy.test.ps1
- workflow-policy.test.ps1
- git diff --check