### PR TITLE
Deploy demo through signed PHP runner

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -54,35 +54,25 @@ jobs:
             -DokuWikiRootName '${{ steps.manifest.outputs.root }}' `
             -OutputArchive "$env:RUNNER_TEMP/dokuwiki-chordsheets-demo.zip"
 
-      - name: Run deployment tests
+      - name: Run deployment policy tests
         shell: pwsh
         run: |
           ./deployment/tests/artifact-build.test.ps1
           ./deployment/tests/zip-output.test.ps1
           ./deployment/tests/workflow-policy.test.ps1
-          ./deployment/tests/fail-closed-rollback.test.ps1
-          ./deployment/tests/canonical-root.test.ps1
-          ./deployment/tests/remote-upload-name.test.ps1
-          ./deployment/tests/remote-upload-preflight-policy.test.ps1
-          ./deployment/tests/remote-shell-policy.test.ps1
-          ./deployment/tests/upload-cleanup.test.ps1
+          ./deployment/tests/php-web-deploy-policy.test.ps1
 
-      - name: Simulate remote ZIP release and rollback
+      - name: Test PHP web deployment and rollback
         shell: bash
         run: |
           set -euo pipefail
           docker run --rm \
-            --entrypoint bash \
-            --tmpfs /home/www:rw,exec,nosuid,size=128m \
             -v "$RUNNER_TEMP/dokuwiki-chordsheets-demo.zip:/input/release.zip:ro" \
             -v "$GITHUB_WORKSPACE/deployment:/repo/deployment:ro" \
-            dokuwiki/dokuwiki:2026-07-14a@sha256:5bab64f737257fa5778b35cc920bd9527fb133a71a7535fb2ef319ecc93b384e \
-            -lc '
-              apt-get update -qq
-              DEBIAN_FRONTEND=noninteractive apt-get install -y -qq unzip >/dev/null
-              bash /repo/deployment/tests/remote-upload-preflight.integration.sh /repo/deployment/remote-upload-preflight.sh
-              bash /repo/deployment/tests/remote-deploy.integration.sh /input/release.zip
-            '
+            composer:2@sha256:f0809732b2188154b3faa8e44ab900595acb0b09cd0aa6c34e798efe4ebc9021 \
+            php /repo/deployment/tests/web-deploy.integration.php \
+              /repo/deployment/web-deploy.php \
+              /input/release.zip
 
       - name: Run local DokuWiki smoke test
         shell: pwsh
@@ -93,114 +83,161 @@ jobs:
             docker compose down --volumes
           }
 
-      - name: Deploy one ZIP over SFTP and SSH
+      - name: Deploy one ZIP over explicit FTPS and activate over HTTPS
         if: ${{ inputs.deploy }}
         shell: bash
         env:
-          SSHPASS: ${{ secrets.FTP_PASSWORD }}
+          FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
           FTP_SERVER: ${{ secrets.FTP_SERVER }}
           FTP_USERNAME: ${{ secrets.FTP_USERNAME }}
-          FTP_KNOWN_HOSTS: ${{ vars.FTP_KNOWN_HOSTS }}
           FTP_PORT: ${{ vars.FTP_PORT }}
-          FTP_REMOTE_PATH: ${{ vars.FTP_REMOTE_PATH }}
           DEMO_URL: ${{ vars.DEMO_URL }}
         run: |
           set -euo pipefail
+          umask 0077
 
-          : "${SSHPASS:?FTP_PASSWORD is required}"
+          : "${FTP_PASSWORD:?FTP_PASSWORD is required}"
           : "${FTP_SERVER:?FTP_SERVER is required}"
           : "${FTP_USERNAME:?FTP_USERNAME is required}"
-          : "${FTP_KNOWN_HOSTS:?FTP_KNOWN_HOSTS is required}"
-          : "${FTP_REMOTE_PATH:?FTP_REMOTE_PATH is required}"
           : "${DEMO_URL:?DEMO_URL is required}"
 
-          FTP_PORT=${FTP_PORT:-22}
-          [[ "$FTP_PORT" == '22' ]]
+          FTP_PORT=${FTP_PORT:-21}
+          [[ "$FTP_PORT" == '21' ]]
           [[ "$FTP_SERVER" =~ ^[A-Za-z0-9.-]+$ ]]
           [[ "$FTP_USERNAME" =~ ^[A-Za-z0-9._-]+$ ]]
-          [[ "$FTP_REMOTE_PATH" == '/home/www/chordsheets-demo' ]]
           [[ "$DEMO_URL" == 'https://chordsheets.pazureck.de' ]]
 
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends sshpass
+          release_archive="$RUNNER_TEMP/dokuwiki-chordsheets-demo.zip"
+          runner_source="$GITHUB_WORKSPACE/deployment/web-deploy.php"
+          archive_sha256=$(sha256sum "$release_archive" | awk '{print $1}')
+          nonce=$(openssl rand -hex 16)
+          deploy_secret=$(openssl rand -hex 32)
+          expires_at=$(($(date +%s) + 900))
+          runner_name=".deploy-$nonce.php"
+          archive_name=".release-$nonce.zip"
+          token_name=".deploy-$nonce.json"
+          runner_url="$DEMO_URL/$runner_name"
+          ftp_base="ftp://$FTP_SERVER:$FTP_PORT"
+          token_file="$RUNNER_TEMP/$token_name"
+          request_file="$RUNNER_TEMP/deployment-request.json"
+          response_file="$RUNNER_TEMP/deployment-response.json"
 
-          install -d -m 0700 "$HOME/.ssh"
-          printf '%s\n' "$FTP_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
-          chmod 0600 "$HOME/.ssh/known_hosts"
+          jq -n \
+            --arg nonce "$nonce" \
+            --arg sha "$GITHUB_SHA" \
+            --arg archive "$archive_name" \
+            --arg archive_sha256 "$archive_sha256" \
+            --arg secret "$deploy_secret" \
+            --argjson expires_at "$expires_at" \
+            '{
+              version: 1,
+              nonce: $nonce,
+              sha: $sha,
+              archive: $archive,
+              archive_sha256: $archive_sha256,
+              secret: $secret,
+              expires_at: $expires_at,
+              phase: "uploaded"
+            }' > "$token_file"
 
-          ssh_options=(
-            -p "$FTP_PORT"
-            -o BatchMode=no
-            -o PreferredAuthentications=password
-            -o PubkeyAuthentication=no
-            -o StrictHostKeyChecking=yes
-            -o UserKnownHostsFile="$HOME/.ssh/known_hosts"
-            -o GlobalKnownHostsFile=/dev/null
+          ftp_options=(
+            --fail
+            --silent
+            --show-error
+            --ssl-reqd
+            --tlsv1.2
+            --user "$FTP_USERNAME:$FTP_PASSWORD"
           )
 
-          release_archive="$RUNNER_TEMP/dokuwiki-chordsheets-demo.zip"
-          archive_sha256=$(sha256sum "$release_archive" | awk '{print $1}')
+          ftp_upload() {
+            local source_file=$1
+            local target_path=$2
+            curl "${ftp_options[@]}" \
+              --ftp-create-dirs \
+              --upload-file "$source_file" \
+              "$ftp_base$target_path"
+          }
 
-          if ! remote_shell_probe=$(sshpass -e ssh "${ssh_options[@]}" \
-            "$FTP_USERNAME@$FTP_SERVER" \
-            "command -v bash >/dev/null 2>&1 && printf REMOTE_SHELL_OK"); then
-            echo 'SSH account does not permit remote Bash command execution; use a Webgo SSH-enabled account rather than an FTP-only account.' >&2
-            exit 1
-          fi
-          if [[ "$remote_shell_probe" != 'REMOTE_SHELL_OK' ]]; then
-            echo 'Remote Bash capability probe returned an unexpected response.' >&2
-            exit 1
-          fi
-
-          if ! remote_result=$(sshpass -e ssh "${ssh_options[@]}" \
-            "$FTP_USERNAME@$FTP_SERVER" \
-            "bash -s -- '$FTP_REMOTE_PATH' '$GITHUB_SHA'" \
-            < deployment/remote-upload-preflight.sh); then
-            echo 'Remote upload preflight failed.' >&2
-            exit 1
-          fi
-          [[ "$remote_result" =~ ^UPLOAD:(\.upload\.$GITHUB_SHA\.[A-Za-z0-9]{6})$ ]]
-          upload_name=${BASH_REMATCH[1]}
-          remote_archive="$FTP_REMOTE_PATH/uploads/$upload_name"
-          remote_upload_pending=1
-
-          cleanup_remote_upload() {
-            if [[ "$remote_upload_pending" -eq 0 ]]; then
-              return
-            fi
-
-            if ! sshpass -e ssh "${ssh_options[@]}" \
-              "$FTP_USERNAME@$FTP_SERVER" \
-              "rm -f -- '$remote_archive'"; then
-              echo 'Warning: failed to remove pending remote upload.' >&2
+          ftp_delete() {
+            local target_path=$1
+            if ! curl "${ftp_options[@]}" \
+              --quote "DELE $target_path" \
+              --list-only \
+              --output /dev/null \
+              "$ftp_base/" >/dev/null 2>&1; then
+              return 0
             fi
           }
-          trap cleanup_remote_upload EXIT
 
-          sshpass -e scp \
-            -P "$FTP_PORT" \
-            -o BatchMode=no \
-            -o PreferredAuthentications=password \
-            -o PubkeyAuthentication=no \
-            -o StrictHostKeyChecking=yes \
-            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
-            -o GlobalKnownHostsFile=/dev/null \
-            "$release_archive" \
-            "$FTP_USERNAME@$FTP_SERVER:$remote_archive"
+          invoke_runner() {
+            local action=$1
+            local expected_state=$2
+            local timestamp canonical signature
+            timestamp=$(date +%s)
+            jq -n \
+              --arg action "$action" \
+              --arg nonce "$nonce" \
+              --arg sha "$GITHUB_SHA" \
+              --argjson timestamp "$timestamp" \
+              --arg archive_sha256 "$archive_sha256" \
+              '{
+                action: $action,
+                nonce: $nonce,
+                sha: $sha,
+                timestamp: $timestamp,
+                archive_sha256: $archive_sha256
+              }' > "$request_file"
+            printf -v canonical '%s\n%s\n%s\n%s\n%s' \
+              "$action" "$nonce" "$GITHUB_SHA" "$timestamp" "$archive_sha256"
+            signature=$(printf '%s' "$canonical" \
+              | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$deploy_secret" \
+              | awk '{print $NF}')
 
-          sshpass -e ssh "${ssh_options[@]}" \
-            "$FTP_USERNAME@$FTP_SERVER" \
-            "bash -s -- '$FTP_REMOTE_PATH' '$GITHUB_SHA' '$archive_sha256' '$upload_name'" \
-            < deployment/remote-deploy.sh
+            if ! curl --fail-with-body --silent --show-error \
+              --proto '=https' --tlsv1.2 \
+              --header 'Content-Type: application/json' \
+              --header "X-Deploy-Signature: $signature" \
+              --data-binary "@$request_file" \
+              --output "$response_file" \
+              "$runner_url"; then
+              if [[ -s "$response_file" ]]; then
+                jq -r '.error // "Remote PHP deployment request failed."' \
+                  "$response_file" 2>/dev/null
+              fi
+              return 1
+            fi
+            jq -e --arg expected "$expected_state" \
+              '.ok == true and .state == $expected' \
+              "$response_file" >/dev/null
+          }
 
-          remote_upload_pending=0
-          trap - EXIT
+          deployment_may_be_active=0
+          cleanup_deployment() {
+            local status=$?
+            trap - EXIT
+            set +e
+            if [[ "$deployment_may_be_active" -eq 1 ]]; then
+              invoke_runner rollback rolled_back >/dev/null 2>&1
+            fi
+            ftp_delete "/current/$runner_name"
+            ftp_delete "/uploads/$archive_name"
+            ftp_delete "/uploads/$token_name"
+            exit "$status"
+          }
+          trap cleanup_deployment EXIT
+
+          ftp_upload "$release_archive" "/uploads/$archive_name"
+          ftp_upload "$runner_source" "/current/$runner_name"
+          ftp_upload "$token_file" "/uploads/$token_name"
+
+          deployment_may_be_active=1
+          invoke_runner deploy active
+
           smoke_failed=0
           curl --fail --silent --show-error \
             "$DEMO_URL/doku.php?id=start" \
             | grep --fixed-strings 'DokuWiki Chordsheets Demo' \
             >/dev/null || smoke_failed=1
-
           curl --fail --silent --show-error \
             "$DEMO_URL/lib/plugins/chordsheets/script.js" \
             >/dev/null || smoke_failed=1
@@ -214,7 +251,6 @@ jobs:
             '/data/'
             '/data/pages/start.txt'
           )
-
           for protected_path in "${protected_paths[@]}"; do
             status=$(curl --silent --show-error --output /dev/null \
               --write-out '%{http_code}' \
@@ -225,65 +261,16 @@ jobs:
           redirect_result=$(curl --silent --show-error --output /dev/null \
             --write-out '%{http_code} %{redirect_url}' \
             'http://chordsheets.pazureck.de/') || redirect_result='000'
-          [[ "$redirect_result" =~ ^30[1278]\ https://chordsheets\.pazureck\.de/ ]] || smoke_failed=1
+          [[ "$redirect_result" =~ ^30[1278]\ https://chordsheets\.pazureck\.de/ ]] \
+            || smoke_failed=1
 
           if [[ "$smoke_failed" -ne 0 ]]; then
-            expected_rollback=$(sshpass -e ssh "${ssh_options[@]}" \
-              "$FTP_USERNAME@$FTP_SERVER" \
-              "if [[ -L '$FTP_REMOTE_PATH/previous' ]]; then readlink '$FTP_REMOTE_PATH/previous'; else printf inactive; fi")
-            [[ "$expected_rollback" == 'inactive' || "$expected_rollback" =~ ^releases/[a-f0-9]{40}$ ]]
-
-            sshpass -e ssh "${ssh_options[@]}" \
-              "$FTP_USERNAME@$FTP_SERVER" \
-              "bash -s -- '$FTP_REMOTE_PATH' '$GITHUB_SHA'" \
-              < deployment/remote-rollback.sh
-
-            rollback_state=$(sshpass -e ssh "${ssh_options[@]}" \
-              "$FTP_USERNAME@$FTP_SERVER" \
-              "if [[ -L '$FTP_REMOTE_PATH/current' ]]; then printf active; else printf inactive; fi")
-            rollback_verification_failed=0
-
-            for protected_path in "${protected_paths[@]}"; do
-              status=$(curl --silent --show-error --output /dev/null \
-                --write-out '%{http_code}' \
-                "$DEMO_URL$protected_path") || status=000
-              [[ "$status" == '403' || "$status" == '404' ]] || rollback_verification_failed=1
-            done
-
-            if [[ "$rollback_state" == 'active' ]]; then
-              [[ "$expected_rollback" =~ ^releases/[a-f0-9]{40}$ ]] || rollback_verification_failed=1
-              curl --fail --silent --show-error \
-                "$DEMO_URL/doku.php?id=start" \
-                | grep --fixed-strings 'DokuWiki Chordsheets Demo' \
-                >/dev/null || rollback_verification_failed=1
-              curl --fail --silent --show-error \
-                "$DEMO_URL/lib/plugins/chordsheets/script.js" \
-                >/dev/null || rollback_verification_failed=1
-            elif [[ "$rollback_state" == 'inactive' ]]; then
-              [[ "$expected_rollback" == 'inactive' ]] || rollback_verification_failed=1
-            else
-              rollback_verification_failed=1
-            fi
-
-            if [[ "$rollback_verification_failed" -ne 0 ]]; then
-              if [[ "$rollback_state" == 'active' && "$expected_rollback" =~ ^releases/[a-f0-9]{40}$ ]]; then
-                rollback_sha=${expected_rollback#releases/}
-                sshpass -e ssh "${ssh_options[@]}" \
-                  "$FTP_USERNAME@$FTP_SERVER" \
-                  "bash -s -- '$FTP_REMOTE_PATH' '$rollback_sha'" \
-                  < deployment/remote-deactivate.sh
-              fi
-
-              post_deactivate_state=$(sshpass -e ssh "${ssh_options[@]}" \
-                "$FTP_USERNAME@$FTP_SERVER" \
-                "if [[ -L '$FTP_REMOTE_PATH/current' ]]; then printf active; else printf inactive; fi")
-              [[ "$post_deactivate_state" == 'inactive' ]]
-              echo 'Rollback verification failed; the unverified release was deactivated.' >&2
-              exit 1
-            fi
-
+            invoke_runner rollback rolled_back
+            deployment_may_be_active=0
             echo 'Remote smoke test failed; rollback completed.' >&2
             exit 1
           fi
 
+          invoke_runner commit committed
+          deployment_may_be_active=0
           echo "Demo ZIP deployment succeeded for $GITHUB_SHA."

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -6,15 +6,17 @@ and users live in `shared/conf`.
 
 ## Server prerequisites
 
-- The Webgo subdomain `chordsheets.pazureck.de` points to
-  `/chordsheets-demo/current`.
-- PHP 8.3 is selected for the subdomain.
+- `chordsheets.pazureck.de` points to `/chordsheets-demo/current`.
+- PHP 8.3 or newer with the `ZipArchive` extension is selected for the domain.
 - A valid Let's Encrypt certificate is active and HTTP redirects to the same
   HTTPS hostname.
-- The credentials belong to the SSH/SFTP-capable Webgo main account on port
-  22. A plain FTP-only account is not supported by this workflow.
-- The account provides `bash`, `unzip`, `zipinfo`, `realpath`, `sha256sum`,
-  `stat`, and `php`.
+- The additional Webgo FTP account is rooted at `/chordsheets-demo`.
+- The FTP endpoint supports explicit TLS on port 21. The workflow refuses
+  plaintext FTP and never disables certificate verification.
+
+Webgo documents that additional FTP users are FTP-only. Therefore this
+deployment does not require SSH or a remote shell. The application is still
+uploaded as one ZIP rather than as thousands of individual files.
 
 ## GitHub environment
 
@@ -26,20 +28,10 @@ Environment secrets:
 - `FTP_USERNAME`
 - `FTP_PASSWORD`
 
-The `FTP_*` names are retained for compatibility, but the transport is
-encrypted SSH/SCP, not plain FTP.
-
 Environment variables:
 
-- `FTP_PORT=22`
-- `FTP_REMOTE_PATH=/home/www/chordsheets-demo`
+- `FTP_PORT=21`
 - `DEMO_URL=https://chordsheets.pazureck.de`
-- `FTP_KNOWN_HOSTS=<verified OpenSSH known_hosts line>`
-
-Obtain the server key from the configured SSH hostname and compare its
-fingerprint with an independently trusted value from Webgo before storing the
-complete known-hosts line. Do not disable strict host-key checking and do not
-trust an unverified `ssh-keyscan` result.
 
 The environment is restricted to the `master` branch. The workflow can only be
 started manually and defaults to a build/test-only run. Set its `deploy` input
@@ -47,23 +39,37 @@ to `true` only for an intended release.
 
 ## Release process
 
-The workflow builds one verified `dokuwiki-chordsheets-demo.zip`. It creates a
-random, private upload file on the server, uploads exactly that one ZIP with
-SCP, verifies its SHA-256, and extracts it into a fresh staging directory with
-`unzip`. No application files are uploaded individually.
+The workflow builds one verified `dokuwiki-chordsheets-demo.zip`. For each
+deployment it generates a 128-bit random runner name and a separate 256-bit
+HMAC secret. It uploads over explicit FTPS:
 
-Before extraction, the server CRC-tests the ZIP and rejects unsafe paths,
-links and special files, duplicate case-insensitive names, oversized archives,
-excessive expansion ratios, unsafe persistent storage, and concurrent
-deployments. The enforced demo configuration and ACL are repaired on each
-release while existing users and wiki data are preserved. A validated release
-is activated atomically through the `current` symlink.
+1. the single application ZIP into `/uploads`;
+2. a short-lived authorization file outside the public document root;
+3. the generic PHP runner under a random name in `/current`.
 
-The first deployment creates this layout:
+The pipeline then calls the runner over HTTPS with a timestamped HMAC-signed
+JSON request. The secret is never placed in the URL or repository. Requests
+expire after five minutes and each deployment phase can only run once.
+
+The PHP runner verifies the ZIP checksum, compressed and expanded sizes, entry
+count, compression ratio, path safety, duplicate names, and Unix entry types.
+It rejects links, devices, traversal paths, `install.php`, and mutable DokuWiki
+data in the release. It never invokes a shell.
+
+The runner extracts into a fresh release directory, links the shared
+configuration and wiki data, and switches `/current` to the new release. The
+pipeline performs public smoke and access-control tests before sending a
+signed commit request. If a test fails or the job terminates after activation,
+it sends a signed rollback request. Runner, authorization file, and ZIP are
+removed after commit or rollback; the pipeline additionally attempts exact
+FTP cleanup.
+
+The resulting layout is:
 
 ```text
-/home/www/chordsheets-demo/
+/chordsheets-demo/
   current -> releases/<git-sha>
+  previous -> releases/<former-git-sha>
   releases/
   shared/
     conf/
@@ -71,17 +77,9 @@ The first deployment creates this layout:
   uploads/
 ```
 
-From the second deployment onward, `previous` points to the former release for
-rollback.
-
 The setup boots DokuWiki without `install.php`, enables ACLs, disables
-registration, and grants anonymous users read-only access. Authenticated users
-can later be granted edit access to `demo:*` and `playground:*`.
-
-No default administrator or password is created. Provision the first
-administrator separately over SSH with a precomputed DokuWiki password hash.
-Never place a plaintext administrator password in the repository or release
-artifact, and never expose the web installer.
+registration, and grants anonymous users read-only access. No default
+administrator or password is created.
 
 ## Verification
 
@@ -91,16 +89,13 @@ Local checks:
 ./deployment/tests/artifact-build.test.ps1
 ./deployment/tests/zip-output.test.ps1
 ./deployment/tests/workflow-policy.test.ps1
+./deployment/tests/php-web-deploy-policy.test.ps1
+docker run --rm `
+  -v "${PWD}/deployment:/repo/deployment:ro" `
+  composer:2@sha256:f0809732b2188154b3faa8e44ab900595acb0b09cd0aa6c34e798efe4ebc9021 `
+  php /repo/deployment/tests/web-deploy.integration.php /repo/deployment/web-deploy.php
 ./docker/smoke-test.ps1
 ```
 
-The GitHub workflow also simulates two remote releases and both rollback paths
-inside a temporary Docker filesystem. A live deployment succeeds only if the
-start page and plugin asset load, sensitive `conf` and `data` paths remain
-blocked, `install.php` is unavailable, and HTTP redirects to the correct HTTPS
-hostname.
-
-If the smoke test fails, rollback is scoped to the Git SHA that was just
-deployed. With no earlier release, the unsafe `current` link is removed; with a
-previous release, the link is switched back atomically and its public page and
-plugin asset are tested again.
+The integration test covers invalid signatures, first activation and cleanup,
+a second release, and rollback to the previous release.

--- a/deployment/tests/php-web-deploy-policy.test.ps1
+++ b/deployment/tests/php-web-deploy-policy.test.ps1
@@ -1,0 +1,61 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$workflowPath = Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml'
+$runnerPath = Join-Path $repositoryRoot 'deployment\web-deploy.php'
+
+if (-not (Test-Path -LiteralPath $runnerPath -PathType Leaf)) {
+    throw 'Missing deployment/web-deploy.php.'
+}
+
+$workflow = Get-Content -Raw -LiteralPath $workflowPath
+$runner = Get-Content -Raw -LiteralPath $runnerPath
+
+foreach ($requiredWorkflowPattern in @(
+    '--ssl-reqd',
+    'deployment/web-deploy\.php',
+    'X-Deploy-Signature:',
+    'https://chordsheets\.pazureck\.de',
+    'dokuwiki-chordsheets-demo\.zip'
+)) {
+    if ($workflow -notmatch $requiredWorkflowPattern) {
+        throw "Workflow is missing required PHP deployment pattern: $requiredWorkflowPattern"
+    }
+}
+
+foreach ($forbiddenWorkflowPattern in @(
+    'sshpass',
+    'StrictHostKeyChecking',
+    '\bscp\b',
+    'ftp://[^"$]*:[^"$]*@'
+)) {
+    if ($workflow -match $forbiddenWorkflowPattern) {
+        throw "Workflow still contains forbidden SSH or credential-in-URL pattern: $forbiddenWorkflowPattern"
+    }
+}
+
+foreach ($requiredRunnerPattern in @(
+    'hash_hmac',
+    'hash_equals',
+    'ZipArchive',
+    'getExternalAttributesIndex',
+    'REQUEST_METHOD',
+    'application/json',
+    'expires_at',
+    'unlink\(__FILE__\)'
+)) {
+    if ($runner -notmatch $requiredRunnerPattern) {
+        throw "PHP runner is missing security control: $requiredRunnerPattern"
+    }
+}
+
+if ($runner -match 'shell_exec|exec\s*\(|system\s*\(|passthru\s*\(') {
+    throw 'PHP runner must not invoke a shell.'
+}
+
+if ($runner -match 'HTTP_X_FORWARDED_PROTO') {
+    throw 'PHP runner must not trust a client-controlled forwarded-protocol header.'
+}
+
+Write-Host 'php-web-deploy-policy.test.ps1: PASS'

--- a/deployment/tests/web-deploy.integration.php
+++ b/deployment/tests/web-deploy.integration.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+define('CHORDSHEETS_DEPLOY_TESTING', true);
+require $argv[1] ?? __DIR__ . '/../web-deploy.php';
+
+function testAssert(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+function testRemoveTree(string $path): void
+{
+    if (is_link($path) || is_file($path)) {
+        @unlink($path);
+        return;
+    }
+    if (!is_dir($path)) {
+        return;
+    }
+    foreach (new FilesystemIterator($path, FilesystemIterator::SKIP_DOTS) as $entry) {
+        testRemoveTree($entry->getPathname());
+    }
+    rmdir($path);
+}
+
+function testCreateArchive(string $archivePath, string $label, ?string $sourceArchive = null): string
+{
+    if ($sourceArchive !== null) {
+        testAssert(is_file($sourceArchive), 'Full release ZIP is unavailable.');
+        testAssert(copy($sourceArchive, $archivePath), 'Could not copy full release ZIP.');
+        return hash_file('sha256', $archivePath);
+    }
+    $zip = new ZipArchive();
+    testAssert($zip->open($archivePath, ZipArchive::CREATE | ZipArchive::OVERWRITE) === true, 'Could not create test ZIP.');
+    $zip->addFromString('doku.php', "<?php echo '" . addslashes($label) . "';");
+    $zip->addFromString('inc/init.php', "<?php\n");
+    $zip->addFromString('lib/plugins/chordsheets/syntax.php', "<?php\n");
+    $zip->addFromString('lib/plugins/chordsheets/script.js', "console.log('demo');\n");
+    $zip->addEmptyDir('conf');
+    $zip->close();
+    return hash_file('sha256', $archivePath);
+}
+
+function testWriteToken(
+    string $root,
+    string $nonce,
+    string $sha,
+    string $archiveName,
+    string $archiveHash,
+    string $secret
+): string {
+    $tokenPath = "$root/uploads/.deploy-$nonce.json";
+    $token = [
+        'version' => 1,
+        'nonce' => $nonce,
+        'sha' => $sha,
+        'archive' => $archiveName,
+        'archive_sha256' => $archiveHash,
+        'secret' => $secret,
+        'expires_at' => time() + 600,
+        'phase' => 'uploaded',
+    ];
+    testAssert(file_put_contents($tokenPath, json_encode($token, JSON_THROW_ON_ERROR), LOCK_EX) !== false, 'Could not write token.');
+    chmod($tokenPath, 0600);
+    return $tokenPath;
+}
+
+function testSignedRequest(array $request, string $secret): string
+{
+    return hash_hmac('sha256', chordsheetsDeployCanonicalRequest($request), $secret);
+}
+
+if (!class_exists(ZipArchive::class)) {
+    throw new RuntimeException('ZipArchive is required for this integration test.');
+}
+
+$root = sys_get_temp_dir() . '/chordsheets-php-deploy-' . bin2hex(random_bytes(8));
+$current = "$root/current";
+$uploads = "$root/uploads";
+mkdir($current, 0700, true);
+mkdir($uploads, 0700, true);
+
+try {
+    $runnerSource = realpath($argv[1] ?? __DIR__ . '/../web-deploy.php');
+    testAssert(is_string($runnerSource), 'Runner source not found.');
+
+    $nonce1 = str_repeat('1', 32);
+    $sha1 = str_repeat('a', 40);
+    $secret1 = str_repeat('b', 64);
+    $runnerName1 = ".deploy-$nonce1.php";
+    $archiveName1 = ".release-$nonce1.zip";
+    $archivePath1 = "$uploads/$archiveName1";
+    $archiveHash1 = testCreateArchive($archivePath1, 'release-one', $argv[2] ?? null);
+    copy($runnerSource, "$current/$runnerName1");
+    $tokenPath1 = testWriteToken($root, $nonce1, $sha1, $archiveName1, $archiveHash1, $secret1);
+
+    $invalidRequest = [
+        'action' => 'deploy',
+        'nonce' => $nonce1,
+        'sha' => $sha1,
+        'timestamp' => time(),
+        'archive_sha256' => $archiveHash1,
+    ];
+    try {
+        chordsheetsDeployExecute($invalidRequest, str_repeat('0', 64), $current, "$current/$runnerName1");
+        throw new RuntimeException('Invalid signature was accepted.');
+    } catch (ChordsheetsDeployException $exception) {
+        testAssert($exception->httpStatus === 403, 'Invalid signature did not return 403.');
+    }
+    testAssert(is_file($tokenPath1), 'Invalid request changed deployment state.');
+
+    $result1 = chordsheetsDeployExecute(
+        $invalidRequest,
+        testSignedRequest($invalidRequest, $secret1),
+        $current,
+        "$current/$runnerName1"
+    );
+    testAssert($result1['state'] === 'active', 'First release was not activated.');
+    testAssert(is_link($current), 'Current was not switched to a release symlink.');
+    testAssert(readlink($current) === "releases/$sha1", 'Current points to the wrong first release.');
+    testAssert(is_file("$current/lib/plugins/chordsheets/syntax.php"), 'Plugin entry point is missing.');
+    testAssert(is_file("$root/shared/conf/local.php"), 'Shared local configuration is missing.');
+    testAssert(is_file("$root/shared/data/pages/start.txt"), 'Demo start page is missing.');
+
+    $commit1 = $invalidRequest;
+    $commit1['action'] = 'commit';
+    $commit1['timestamp'] = time();
+    $resultCommit1 = chordsheetsDeployExecute(
+        $commit1,
+        testSignedRequest($commit1, $secret1),
+        $current,
+        "$current/$runnerName1"
+    );
+    testAssert($resultCommit1['state'] === 'committed', 'First release was not committed.');
+    testAssert(!file_exists($tokenPath1), 'Token survived commit.');
+    testAssert(!file_exists($archivePath1), 'Archive survived commit.');
+    testAssert(!file_exists("$current/$runnerName1"), 'Runner survived commit.');
+
+    $nonce2 = str_repeat('2', 32);
+    $sha2 = str_repeat('c', 40);
+    $secret2 = str_repeat('d', 64);
+    $runnerName2 = ".deploy-$nonce2.php";
+    $archiveName2 = ".release-$nonce2.zip";
+    $archivePath2 = "$uploads/$archiveName2";
+    $archiveHash2 = testCreateArchive($archivePath2, 'release-two', $argv[2] ?? null);
+    copy($runnerSource, "$current/$runnerName2");
+    $tokenPath2 = testWriteToken($root, $nonce2, $sha2, $archiveName2, $archiveHash2, $secret2);
+    $deploy2 = [
+        'action' => 'deploy',
+        'nonce' => $nonce2,
+        'sha' => $sha2,
+        'timestamp' => time(),
+        'archive_sha256' => $archiveHash2,
+    ];
+    $result2 = chordsheetsDeployExecute(
+        $deploy2,
+        testSignedRequest($deploy2, $secret2),
+        $current,
+        "$current/$runnerName2"
+    );
+    testAssert($result2['state'] === 'active', 'Second release was not activated.');
+    testAssert(readlink($current) === "releases/$sha2", 'Current points to the wrong second release.');
+
+    $rollback2 = $deploy2;
+    $rollback2['action'] = 'rollback';
+    $rollback2['timestamp'] = time();
+    $resultRollback2 = chordsheetsDeployExecute(
+        $rollback2,
+        testSignedRequest($rollback2, $secret2),
+        $current,
+        "$current/$runnerName2"
+    );
+    testAssert($resultRollback2['state'] === 'rolled_back', 'Second release was not rolled back.');
+    testAssert(readlink($current) === "releases/$sha1", 'Rollback did not restore the first release.');
+    testAssert(!file_exists("$root/releases/$sha2"), 'Rolled-back release was not removed.');
+    testAssert(!file_exists($tokenPath2), 'Rollback token survived.');
+    testAssert(!file_exists($archivePath2), 'Rollback archive survived.');
+
+    echo "web-deploy.integration.php: PASS\n";
+} finally {
+    testRemoveTree($root);
+}

--- a/deployment/tests/workflow-policy.test.ps1
+++ b/deployment/tests/workflow-policy.test.ps1
@@ -3,9 +3,7 @@ Set-StrictMode -Version Latest
 
 $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $workflowPath = Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml'
-$remotePreflightPath = Join-Path $repositoryRoot 'deployment\remote-upload-preflight.sh'
-$remoteDeployPath = Join-Path $repositoryRoot 'deployment\remote-deploy.sh'
-$remoteRollbackPath = Join-Path $repositoryRoot 'deployment\remote-rollback.sh'
+$runnerPath = Join-Path $repositoryRoot 'deployment\web-deploy.php'
 
 function Assert-Match {
     param([string]$Content, [string]$Pattern, [string]$Message)
@@ -17,16 +15,14 @@ function Assert-NoMatch {
     if ($Content -match $Pattern) { throw $Message }
 }
 
-foreach ($requiredPath in @($workflowPath, $remotePreflightPath, $remoteDeployPath, $remoteRollbackPath)) {
+foreach ($requiredPath in @($workflowPath, $runnerPath)) {
     if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
         throw "Missing deployment file: $requiredPath"
     }
 }
 
 $workflow = Get-Content -Raw -LiteralPath $workflowPath
-$remotePreflight = Get-Content -Raw -LiteralPath $remotePreflightPath
-$remoteDeploy = Get-Content -Raw -LiteralPath $remoteDeployPath
-$remoteRollback = Get-Content -Raw -LiteralPath $remoteRollbackPath
+$runner = Get-Content -Raw -LiteralPath $runnerPath
 
 Assert-Match $workflow '(?m)^\s*workflow_dispatch:\s*$' 'Workflow must be manually dispatched.'
 Assert-NoMatch $workflow '(?m)^\s*(push|pull_request|pull_request_target|schedule):\s*$' 'Workflow must not deploy automatically.'
@@ -34,23 +30,24 @@ Assert-Match $workflow '(?ms)^permissions:\s*\r?\n\s*contents:\s*read\s*$' 'Work
 Assert-Match $workflow '(?m)^\s*environment:\s*demo\s*$' 'Deploy job must use the demo environment.'
 Assert-Match $workflow '(?m)^\s*cancel-in-progress:\s*false\s*$' 'Deployments must not cancel one another.'
 Assert-Match $workflow 'actions/checkout@[a-f0-9]{40}' 'Checkout action must be commit-pinned.'
-Assert-Match $workflow 'StrictHostKeyChecking=yes' 'SSH must enforce host-key checking.'
-Assert-NoMatch $workflow 'StrictHostKeyChecking=no' 'SSH host-key checks must never be disabled.'
-Assert-Match $workflow 'GlobalKnownHostsFile=/dev/null' 'SSH must not consult global host keys.'
-Assert-NoMatch $workflow '(?i)ftp://|port\s*[:=]\s*21' 'Plain FTP is forbidden.'
-Assert-Match $workflow '\$\{\{\s*vars\.FTP_KNOWN_HOSTS\s*\}\}' 'Workflow must use verified known hosts.'
-Assert-Match $workflow '\[\[\s+"\$FTP_REMOTE_PATH"\s+==\s+''/home/www/chordsheets-demo''\s+\]\]' 'Workflow must pin the remote path.'
-Assert-NoMatch $workflow '\|\|\s*true' 'Rollback failures must not be ignored.'
+Assert-Match $workflow 'composer:2@sha256:[a-f0-9]{64}' 'PHP integration image must be digest-pinned.'
+Assert-Match $workflow '--ssl-reqd' 'FTP transport must require TLS.'
+Assert-Match $workflow '--proto ''=https''' 'Deployment activation must require HTTPS.'
+Assert-Match $workflow 'X-Deploy-Signature:' 'Deployment request must carry an HMAC signature.'
+Assert-Match $workflow 'openssl dgst -sha256 -mac HMAC' 'Pipeline must compute the deployment HMAC locally.'
+Assert-Match $workflow 'deployment_may_be_active' 'Pipeline must track potentially active releases.'
+Assert-Match $workflow 'invoke_runner rollback rolled_back' 'Pipeline must roll back failed deployments.'
+Assert-Match $workflow 'ftp_delete "/current/\$runner_name"' 'Pipeline must clean up the transient PHP runner.'
 Assert-Match $workflow 'dokuwiki-chordsheets-demo\.zip' 'Workflow must deploy one ZIP artifact.'
 Assert-NoMatch $workflow 'dokuwiki-chordsheets-demo\.tgz' 'Workflow must not deploy a tarball.'
-Assert-Match $workflow 'deployment/remote-upload-preflight\.sh' 'Workflow must invoke the remote upload preflight script.'
-Assert-Match $remotePreflight 'mktemp.+\.upload\.\$sha\.XXXXXX' 'Remote preflight must create a random server upload path.'
-Assert-Match $workflow 'rollback_state=' 'Workflow must inspect server state after rollback.'
-Assert-Match $workflow 'rollback_verification_failed' 'Workflow must verify a restored release after rollback.'
+Assert-NoMatch $workflow 'sshpass|\bscp\b|StrictHostKeyChecking|UserKnownHostsFile' 'Workflow must not require an SSH shell.'
+Assert-NoMatch $workflow 'ftp://[^"$\r\n]*:[^"$\r\n]*@' 'Credentials must not be embedded in an FTP URL.'
+Assert-NoMatch $workflow '--insecure|-k(?:\s|$)' 'TLS verification must never be disabled.'
+Assert-NoMatch $workflow '\|\|\s*true' 'Deployment or rollback failures must not be ignored.'
 
-$scpCount = [regex]::Matches($workflow, 'sshpass\s+-e\s+scp').Count
-if ($scpCount -ne 1) {
-    throw "Workflow must contain exactly one SCP upload, found $scpCount."
+$uploadCount = [regex]::Matches($workflow, 'ftp_upload\s+"').Count
+if ($uploadCount -ne 3) {
+    throw "Workflow must upload one ZIP plus one token and one runner, found $uploadCount uploads."
 }
 
 $secretReferences = [regex]::Matches($workflow, 'secrets\.([A-Z0-9_]+)') |
@@ -61,16 +58,12 @@ if (($secretReferences -join ',') -ne ($expectedSecrets -join ',')) {
     throw "Unexpected secret references: $($secretReferences -join ', ')"
 }
 
-Assert-Match $remoteDeploy 'unzip\s+-tqq' 'Remote deploy must CRC-test the ZIP.'
-Assert-Match $remoteDeploy 'unzip\s+-q\s+"\$archive"\s+-d\s+"\$staging"' 'Remote deploy must extract into fresh staging.'
-Assert-Match $remoteDeploy 'zipinfo\s+-l' 'Remote deploy must inspect ZIP entry types.'
-Assert-Match $remoteDeploy '\.deploy\.lock' 'Remote deploy must serialize server operations.'
-Assert-Match $remoteDeploy 'Persistent tree contains a link or special file' 'Remote deploy must reject unsafe persistent entries.'
-Assert-NoMatch $remoteDeploy 'tar\s+-[ctx].*zf' 'Remote deploy must not use tar for the release.'
-Assert-Match $remoteDeploy 'test ! -e|!\s+-e' 'Remote deploy must reject install.php.'
-Assert-Match $remoteRollback '\^\[a-f0-9\]\{40\}\$' 'Rollback must require a full Git SHA.'
-Assert-Match $remoteRollback '\.deploy\.lock' 'Rollback must use the deployment lock.'
-Assert-Match $remoteRollback 'lib/plugins/chordsheets/syntax\.php' 'Rollback must verify the plugin entry point.'
-Assert-NoMatch ($remoteDeploy + $remoteRollback) 'chmod\s+-R\s+777|rm\s+-rf\s+["'']?\$(root|remote_root)' 'Remote scripts contain an unsafe broad mutation.'
+Assert-Match $runner 'hash_hmac' 'PHP runner must verify HMAC requests.'
+Assert-Match $runner 'hash_equals' 'PHP runner must use constant-time signature comparison.'
+Assert-Match $runner 'ZipArchive' 'PHP runner must use PHP ZIP extraction.'
+Assert-Match $runner 'getExternalAttributesIndex' 'PHP runner must inspect ZIP entry types.'
+Assert-Match $runner '536_870_912' 'PHP runner must cap expanded archive size.'
+Assert-Match $runner '25_000' 'PHP runner must cap ZIP entry count.'
+Assert-NoMatch $runner 'shell_exec|exec\s*\(|system\s*\(|passthru\s*\(' 'PHP runner must not invoke a shell.'
 
 Write-Host 'workflow-policy.test.ps1: PASS'

--- a/deployment/web-deploy.php
+++ b/deployment/web-deploy.php
@@ -1,0 +1,660 @@
+<?php
+
+declare(strict_types=1);
+
+final class ChordsheetsDeployException extends RuntimeException
+{
+    public function __construct(string $message, public readonly int $httpStatus = 400)
+    {
+        parent::__construct($message);
+    }
+}
+
+function chordsheetsDeployFail(string $message, int $status = 400): never
+{
+    throw new ChordsheetsDeployException($message, $status);
+}
+
+function chordsheetsDeployCanonicalRequest(array $request): string
+{
+    return implode("\n", [
+        (string) ($request['action'] ?? ''),
+        (string) ($request['nonce'] ?? ''),
+        (string) ($request['sha'] ?? ''),
+        (string) ($request['timestamp'] ?? ''),
+        (string) ($request['archive_sha256'] ?? ''),
+    ]);
+}
+
+function chordsheetsDeployRemoveTree(string $path): void
+{
+    if (is_link($path) || is_file($path)) {
+        if (!unlink($path)) {
+            chordsheetsDeployFail('Deployment cleanup failed.', 500);
+        }
+        return;
+    }
+    if (!is_dir($path)) {
+        return;
+    }
+    foreach (new FilesystemIterator($path, FilesystemIterator::SKIP_DOTS) as $entry) {
+        chordsheetsDeployRemoveTree($entry->getPathname());
+    }
+    if (!rmdir($path)) {
+        chordsheetsDeployFail('Deployment cleanup failed.', 500);
+    }
+}
+
+function chordsheetsDeployWriteFile(string $path, string $contents, int $mode = 0600): void
+{
+    $temporary = $path . '.tmp.' . bin2hex(random_bytes(8));
+    if (file_put_contents($temporary, $contents, LOCK_EX) === false) {
+        chordsheetsDeployFail('Could not write deployment state.', 500);
+    }
+    chmod($temporary, $mode);
+    if (!rename($temporary, $path)) {
+        @unlink($temporary);
+        chordsheetsDeployFail('Could not activate deployment state.', 500);
+    }
+}
+
+function chordsheetsDeployReadToken(string $tokenPath): array
+{
+    if (!is_file($tokenPath) || is_link($tokenPath)) {
+        chordsheetsDeployFail('Deployment authorization is unavailable.', 403);
+    }
+    $size = filesize($tokenPath);
+    if (!is_int($size) || $size < 1 || $size > 4096) {
+        chordsheetsDeployFail('Deployment authorization is invalid.', 403);
+    }
+    try {
+        $token = json_decode((string) file_get_contents($tokenPath), true, 16, JSON_THROW_ON_ERROR);
+    } catch (JsonException) {
+        chordsheetsDeployFail('Deployment authorization is invalid.', 403);
+    }
+    if (!is_array($token)) {
+        chordsheetsDeployFail('Deployment authorization is invalid.', 403);
+    }
+    return $token;
+}
+
+function chordsheetsDeploySaveToken(string $tokenPath, array $token): void
+{
+    chordsheetsDeployWriteFile(
+        $tokenPath,
+        json_encode($token, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+        0600
+    );
+}
+
+function chordsheetsDeployValidateAuthorization(
+    array $request,
+    string $signature,
+    array $token
+): void {
+    $action = $request['action'] ?? null;
+    $nonce = $request['nonce'] ?? null;
+    $sha = $request['sha'] ?? null;
+    $timestamp = $request['timestamp'] ?? null;
+    $archiveHash = $request['archive_sha256'] ?? null;
+
+    if (!is_string($action) || !in_array($action, ['deploy', 'commit', 'rollback'], true)) {
+        chordsheetsDeployFail('Invalid deployment request.');
+    }
+    if (!is_string($nonce) || !preg_match('/^[a-f0-9]{32}$/D', $nonce)) {
+        chordsheetsDeployFail('Invalid deployment request.');
+    }
+    if (!is_string($sha) || !preg_match('/^[a-f0-9]{40}$/D', $sha)) {
+        chordsheetsDeployFail('Invalid deployment request.');
+    }
+    if (!is_int($timestamp) || abs(time() - $timestamp) > 300) {
+        chordsheetsDeployFail('Deployment request expired.', 403);
+    }
+    if (!is_string($archiveHash) || !preg_match('/^[a-f0-9]{64}$/D', $archiveHash)) {
+        chordsheetsDeployFail('Invalid deployment request.');
+    }
+    if (!preg_match('/^[a-f0-9]{64}$/D', $signature)) {
+        chordsheetsDeployFail('Deployment signature is invalid.', 403);
+    }
+
+    $expectedToken = [
+        'version' => 1,
+        'nonce' => $nonce,
+        'sha' => $sha,
+        'archive_sha256' => $archiveHash,
+    ];
+    foreach ($expectedToken as $key => $value) {
+        if (($token[$key] ?? null) !== $value) {
+            chordsheetsDeployFail('Deployment authorization does not match.', 403);
+        }
+    }
+    if (($token['archive'] ?? null) !== ".release-$nonce.zip") {
+        chordsheetsDeployFail('Deployment authorization is invalid.', 403);
+    }
+    if (!isset($token['secret']) || !is_string($token['secret'])
+        || !preg_match('/^[a-f0-9]{64}$/D', $token['secret'])) {
+        chordsheetsDeployFail('Deployment authorization is invalid.', 403);
+    }
+    if (!isset($token['expires_at']) || !is_int($token['expires_at']) || time() > $token['expires_at']) {
+        chordsheetsDeployFail('Deployment authorization expired.', 403);
+    }
+
+    $expectedSignature = hash_hmac(
+        'sha256',
+        chordsheetsDeployCanonicalRequest($request),
+        $token['secret']
+    );
+    if (!hash_equals($expectedSignature, $signature)) {
+        chordsheetsDeployFail('Deployment signature is invalid.', 403);
+    }
+
+    $expectedPhase = $action === 'deploy' ? 'uploaded' : 'active';
+    if (($token['phase'] ?? null) !== $expectedPhase) {
+        chordsheetsDeployFail('Deployment action is not valid in the current state.', 409);
+    }
+}
+
+function chordsheetsDeployValidateArchive(string $archivePath, string $expectedHash): void
+{
+    if (!class_exists(ZipArchive::class)) {
+        chordsheetsDeployFail('Server PHP ZIP support is unavailable.', 500);
+    }
+    if (!is_file($archivePath) || is_link($archivePath)) {
+        chordsheetsDeployFail('Deployment archive is unavailable.', 400);
+    }
+    $archiveSize = filesize($archivePath);
+    if (!is_int($archiveSize) || $archiveSize < 1 || $archiveSize > 67_108_864) {
+        chordsheetsDeployFail('Deployment archive size is invalid.');
+    }
+    if (!hash_equals($expectedHash, hash_file('sha256', $archivePath))) {
+        chordsheetsDeployFail('Deployment archive checksum mismatch.');
+    }
+
+    $zip = new ZipArchive();
+    if ($zip->open($archivePath, ZipArchive::RDONLY) !== true) {
+        chordsheetsDeployFail('Deployment archive could not be opened.');
+    }
+    try {
+        if ($zip->numFiles < 1 || $zip->numFiles > 25_000) {
+            chordsheetsDeployFail('Deployment archive entry count is invalid.');
+        }
+        $seen = [];
+        $unpackedBytes = 0;
+        for ($index = 0; $index < $zip->numFiles; $index++) {
+            $stat = $zip->statIndex($index, ZipArchive::FL_UNCHANGED);
+            if (!is_array($stat) || !isset($stat['name'], $stat['size'], $stat['comp_size'])) {
+                chordsheetsDeployFail('Deployment archive metadata is invalid.');
+            }
+            $name = $stat['name'];
+            if (!is_string($name)
+                || $name === ''
+                || str_starts_with($name, '/')
+                || str_contains($name, '\\')
+                || str_contains($name, '//')
+                || !preg_match('#^[A-Za-z0-9._+@/-]+$#D', $name)
+                || in_array('..', explode('/', trim($name, '/')), true)) {
+                chordsheetsDeployFail('Deployment archive contains an unsafe path.');
+            }
+            $folded = strtolower(rtrim($name, '/'));
+            if ($folded === '' || isset($seen[$folded])) {
+                chordsheetsDeployFail('Deployment archive contains duplicate paths.');
+            }
+            $seen[$folded] = true;
+
+            $operatingSystem = 0;
+            $attributes = 0;
+            if ($zip->getExternalAttributesIndex($index, $operatingSystem, $attributes)) {
+                $fileType = ($attributes >> 16) & 0xF000;
+                if ($fileType !== 0 && $fileType !== 0x8000 && $fileType !== 0x4000) {
+                    chordsheetsDeployFail('Deployment archive contains a link or special file.');
+                }
+            }
+
+            $unpackedBytes += (int) $stat['size'];
+            if ($unpackedBytes > 536_870_912) {
+                chordsheetsDeployFail('Deployment archive expands beyond the size limit.');
+            }
+        }
+        if ($unpackedBytes > $archiveSize * 200) {
+            chordsheetsDeployFail('Deployment archive compression ratio is unsafe.');
+        }
+    } finally {
+        $zip->close();
+    }
+}
+
+function chordsheetsDeployExtractArchive(string $archivePath, string $staging): void
+{
+    $zip = new ZipArchive();
+    if ($zip->open($archivePath, ZipArchive::RDONLY) !== true) {
+        chordsheetsDeployFail('Deployment archive could not be opened.');
+    }
+    try {
+        if (!$zip->extractTo($staging)) {
+            chordsheetsDeployFail('Deployment archive could not be extracted.', 500);
+        }
+    } finally {
+        $zip->close();
+    }
+}
+
+function chordsheetsDeployAssertTreeSafe(string $path): void
+{
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST
+    );
+    foreach ($iterator as $entry) {
+        if ($entry->isLink() || (!$entry->isFile() && !$entry->isDir())) {
+            chordsheetsDeployFail('Expanded deployment contains a link or special file.');
+        }
+    }
+}
+
+function chordsheetsDeploySetReleasePermissions(string $path): void
+{
+    if (!chmod($path, 0755)) {
+        chordsheetsDeployFail('Could not set release permissions.', 500);
+    }
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST
+    );
+    foreach ($iterator as $entry) {
+        if ($entry->isLink()) {
+            continue;
+        }
+        $mode = $entry->isDir() ? 0755 : 0644;
+        if (!chmod($entry->getPathname(), $mode)) {
+            chordsheetsDeployFail('Could not set release permissions.', 500);
+        }
+    }
+}
+
+function chordsheetsDeployPrepareShared(string $root, string $staging, string $sha): void
+{
+    $shared = "$root/shared";
+    $sharedConf = "$shared/conf";
+    $sharedData = "$shared/data";
+    if ((file_exists($shared) || is_link($shared)) && (!is_dir($shared) || is_link($shared))) {
+        chordsheetsDeployFail('Shared deployment path is unsafe.', 500);
+    }
+    if (!is_dir($shared) && !mkdir($shared, 0700, true)) {
+        chordsheetsDeployFail('Could not create shared deployment storage.', 500);
+    }
+
+    if (!is_dir($sharedConf)) {
+        if (!is_dir("$staging/conf") || !rename("$staging/conf", $sharedConf)) {
+            chordsheetsDeployFail('Could not initialize shared configuration.', 500);
+        }
+    } else {
+        if (is_link($sharedConf)) {
+            chordsheetsDeployFail('Shared configuration path is unsafe.', 500);
+        }
+        chordsheetsDeployRemoveTree("$staging/conf");
+    }
+
+    if (!is_dir($sharedData)) {
+        foreach ([
+            'attic', 'cache', 'index', 'locks', 'media', 'media_attic',
+            'media_meta', 'meta', 'pages', 'tmp',
+        ] as $directory) {
+            if (!mkdir("$sharedData/$directory", 0700, true) && !is_dir("$sharedData/$directory")) {
+                chordsheetsDeployFail('Could not initialize shared wiki data.', 500);
+            }
+        }
+        chordsheetsDeployWriteFile(
+            "$sharedData/pages/start.txt",
+            "====== DokuWiki Chordsheets Demo ======\n\n"
+            . "This instance runs the current chordsheets plugin from GitHub.\n\n"
+            . "<chordSheet>\n[C]Hello [G]world\n[Am]This is the [F]guitar demo\n</chordSheet>\n\n"
+            . "<chordSheet instrument=\"ukulele\">\n[C]Ukulele [G]preview\n</chordSheet>\n"
+        );
+    } elseif (is_link($sharedData)) {
+        chordsheetsDeployFail('Shared data path is unsafe.', 500);
+    }
+
+    chordsheetsDeployWriteFile(
+        "$sharedConf/local.php",
+        "<?php\n"
+        . "\$conf['title'] = 'DokuWiki Chordsheets Demo';\n"
+        . "\$conf['lang'] = 'en';\n"
+        . "\$conf['license'] = 'cc-by-sa';\n"
+        . "\$conf['useacl'] = 1;\n"
+        . "\$conf['superuser'] = '@admin';\n"
+        . "\$conf['authtype'] = 'authplain';\n"
+        . "\$conf['disableactions'] = 'register';\n"
+        . "\$conf['breadcrumbs'] = 0;\n"
+        . "\$conf['youarehere'] = 1;\n"
+    );
+    chordsheetsDeployWriteFile(
+        "$sharedConf/acl.auth.php",
+        "# acl.auth.php\n# <?php exit()?>\n"
+        . "*               @ALL        1\n"
+        . "*               @user       1\n"
+        . "demo:*          @user       2\n"
+        . "playground:*    @user       2\n"
+    );
+    if (!file_exists("$sharedConf/users.auth.php")) {
+        chordsheetsDeployWriteFile(
+            "$sharedConf/users.auth.php",
+            "# users.auth.php\n# <?php exit()?>\n"
+        );
+    }
+    $deny = "<IfModule mod_authz_core.c>\n  Require all denied\n</IfModule>\n"
+        . "<IfModule !mod_authz_core.c>\n  Order allow,deny\n  Deny from all\n</IfModule>\n";
+    chordsheetsDeployWriteFile("$sharedConf/.htaccess", $deny);
+    chordsheetsDeployWriteFile("$sharedData/.htaccess", $deny);
+
+    if (!symlink('../../shared/conf', "$staging/conf")
+        || !symlink('../../shared/data', "$staging/data")) {
+        chordsheetsDeployFail('Could not link shared DokuWiki storage.', 500);
+    }
+}
+
+function chordsheetsDeployActivate(
+    string $root,
+    string $documentRoot,
+    string $scriptPath,
+    string $tokenPath,
+    array $token
+): array {
+    $sha = $token['sha'];
+    $nonce = $token['nonce'];
+    $archivePath = "$root/uploads/{$token['archive']}";
+    $releases = "$root/releases";
+    $release = "$releases/$sha";
+    $staging = "$releases/.$sha.$nonce.tmp";
+    $holder = "$root/.previous-$nonce";
+    $next = "$root/current.next-$nonce";
+    $runnerName = basename($scriptPath);
+
+    if (!preg_match('/^\.deploy-' . preg_quote($nonce, '/') . '\.php$/D', $runnerName)) {
+        chordsheetsDeployFail('Deployment runner name is invalid.', 400);
+    }
+    chordsheetsDeployValidateArchive($archivePath, $token['archive_sha256']);
+    if (!is_dir($releases) && !mkdir($releases, 0755, true)) {
+        chordsheetsDeployFail('Could not create release storage.', 500);
+    }
+    if (!chmod($releases, 0755)) {
+        chordsheetsDeployFail('Could not set release storage permissions.', 500);
+    }
+    foreach ([$release, $staging, $holder, $next] as $managedPath) {
+        if (file_exists($managedPath) || is_link($managedPath)) {
+            chordsheetsDeployFail('Deployment state conflicts with an existing path.', 409);
+        }
+    }
+    if (!mkdir($staging, 0700)) {
+        chordsheetsDeployFail('Could not create release staging.', 500);
+    }
+
+    $switched = false;
+    try {
+        chordsheetsDeployExtractArchive($archivePath, $staging);
+        chordsheetsDeployAssertTreeSafe($staging);
+        foreach ([
+            "$staging/doku.php",
+            "$staging/inc/init.php",
+            "$staging/lib/plugins/chordsheets/syntax.php",
+        ] as $requiredPath) {
+            if (!is_file($requiredPath) || is_link($requiredPath)) {
+                chordsheetsDeployFail('Deployment archive is missing required application files.');
+            }
+        }
+        if (file_exists("$staging/install.php")
+            || file_exists("$staging/data")
+            || file_exists("$staging/conf/local.php")) {
+            chordsheetsDeployFail('Deployment archive contains forbidden mutable files.');
+        }
+
+        chordsheetsDeployPrepareShared($root, $staging, $sha);
+        chordsheetsDeploySetReleasePermissions($staging);
+        if (!copy($scriptPath, "$staging/$runnerName")) {
+            chordsheetsDeployFail('Could not stage deployment runner.', 500);
+        }
+        chmod("$staging/$runnerName", 0600);
+        if (!rename($staging, $release)) {
+            chordsheetsDeployFail('Could not finalize release staging.', 500);
+        }
+
+        if (is_link($documentRoot)) {
+            $oldTarget = readlink($documentRoot);
+            if (!is_string($oldTarget)
+                || !preg_match('#^releases/[a-f0-9]{40}$#D', $oldTarget)
+                || !is_dir("$root/$oldTarget")) {
+                chordsheetsDeployFail('Current deployment target is invalid.', 500);
+            }
+            $previousKind = 'symlink';
+        } elseif (is_dir($documentRoot)) {
+            $oldTarget = null;
+            $previousKind = 'directory';
+        } else {
+            chordsheetsDeployFail('Current deployment root is unavailable.', 500);
+        }
+
+        if (!symlink("releases/$sha", $next)) {
+            chordsheetsDeployFail('Could not prepare release activation.', 500);
+        }
+        if (!rename($documentRoot, $holder)) {
+            chordsheetsDeployFail('Could not preserve current deployment.', 500);
+        }
+        if (!rename($next, $documentRoot)) {
+            @rename($holder, $documentRoot);
+            chordsheetsDeployFail('Could not activate release.', 500);
+        }
+        $switched = true;
+
+        $token['phase'] = 'active';
+        $token['runner'] = $runnerName;
+        $token['holder'] = basename($holder);
+        $token['previous_kind'] = $previousKind;
+        $token['previous_target'] = $oldTarget;
+        chordsheetsDeploySaveToken($tokenPath, $token);
+    } catch (Throwable $exception) {
+        if ($switched && (is_link($documentRoot) || is_dir($documentRoot))) {
+            $failed = "$root/.failed-$nonce";
+            if (!file_exists($failed) && !is_link($failed)
+                && rename($documentRoot, $failed)
+                && rename($holder, $documentRoot)) {
+                chordsheetsDeployRemoveTree($failed);
+            }
+        }
+        if (is_dir($staging) && !is_link($staging)) {
+            chordsheetsDeployRemoveTree($staging);
+        }
+        if (is_dir($release) && !is_link($release)
+            && (!is_link($documentRoot) || readlink($documentRoot) !== "releases/$sha")) {
+            chordsheetsDeployRemoveTree($release);
+        }
+        throw $exception;
+    }
+
+    return ['ok' => true, 'state' => 'active', 'release' => $sha];
+}
+
+function chordsheetsDeployFinish(
+    string $root,
+    string $documentRoot,
+    string $scriptPath,
+    string $tokenPath,
+    array $token,
+    bool $rollback
+): array {
+    $nonce = $token['nonce'];
+    $sha = $token['sha'];
+    $runnerName = $token['runner'] ?? '';
+    $holderName = $token['holder'] ?? '';
+    if ($runnerName !== basename($scriptPath)
+        || !preg_match('/^\.deploy-' . preg_quote($nonce, '/') . '\.php$/D', $runnerName)
+        || $holderName !== ".previous-$nonce") {
+        chordsheetsDeployFail('Deployment state is invalid.', 500);
+    }
+    $holder = "$root/$holderName";
+    $archivePath = "$root/uploads/{$token['archive']}";
+    $release = "$root/releases/$sha";
+    if (!is_link($documentRoot) || readlink($documentRoot) !== "releases/$sha") {
+        chordsheetsDeployFail('Active deployment does not match the request.', 409);
+    }
+
+    if ($rollback) {
+        $failedLink = "$root/.failed-$nonce";
+        if (file_exists($failedLink) || is_link($failedLink)
+            || (!is_link($holder) && !is_dir($holder))) {
+            chordsheetsDeployFail('Rollback state is invalid.', 500);
+        }
+        if (!rename($documentRoot, $failedLink) || !rename($holder, $documentRoot)) {
+            @rename($failedLink, $documentRoot);
+            chordsheetsDeployFail('Could not restore previous deployment.', 500);
+        }
+        @unlink($failedLink);
+        @unlink("$documentRoot/$runnerName");
+        @unlink($archivePath);
+        @unlink($tokenPath);
+        if (is_dir($release) && !is_link($release)) {
+            chordsheetsDeployRemoveTree($release);
+        }
+        return ['ok' => true, 'state' => 'rolled_back', 'release' => $sha];
+    }
+
+    @unlink("$holder/$runnerName");
+    if (($token['previous_kind'] ?? null) === 'symlink') {
+        $previous = "$root/previous";
+        if (file_exists($previous) && !is_link($previous)) {
+            chordsheetsDeployFail('Previous deployment pointer is unsafe.', 500);
+        }
+        if (is_link($previous)) {
+            unlink($previous);
+        }
+        if (!rename($holder, $previous)) {
+            chordsheetsDeployFail('Could not retain previous deployment pointer.', 500);
+        }
+    }
+    @unlink($archivePath);
+    @unlink($tokenPath);
+    @unlink($scriptPath);
+    return ['ok' => true, 'state' => 'committed', 'release' => $sha];
+}
+
+function chordsheetsDeployExecute(
+    array $request,
+    string $signature,
+    string $documentRoot,
+    string $scriptPath
+): array {
+    $documentRoot = rtrim($documentRoot, DIRECTORY_SEPARATOR);
+    if (basename($documentRoot) !== 'current') {
+        chordsheetsDeployFail('Deployment document root is invalid.', 500);
+    }
+    $root = dirname($documentRoot);
+    if (!is_dir($root) || is_link($root)) {
+        chordsheetsDeployFail('Deployment root is invalid.', 500);
+    }
+    $nonce = $request['nonce'] ?? '';
+    if (!is_string($nonce) || !preg_match('/^[a-f0-9]{32}$/D', $nonce)) {
+        chordsheetsDeployFail('Invalid deployment request.');
+    }
+    $tokenPath = "$root/uploads/.deploy-$nonce.json";
+    $token = chordsheetsDeployReadToken($tokenPath);
+    chordsheetsDeployValidateAuthorization($request, $signature, $token);
+
+    $lockPath = "$root/.deploy.lock";
+    $lock = @fopen($lockPath, 'x');
+    if ($lock === false) {
+        chordsheetsDeployFail('Another deployment is active.', 409);
+    }
+    chmod($lockPath, 0600);
+    try {
+        fwrite($lock, $nonce);
+        return match ($request['action']) {
+            'deploy' => chordsheetsDeployActivate(
+                $root,
+                $documentRoot,
+                $scriptPath,
+                $tokenPath,
+                $token
+            ),
+            'commit' => chordsheetsDeployFinish(
+                $root,
+                $documentRoot,
+                $scriptPath,
+                $tokenPath,
+                $token,
+                false
+            ),
+            'rollback' => chordsheetsDeployFinish(
+                $root,
+                $documentRoot,
+                $scriptPath,
+                $tokenPath,
+                $token,
+                true
+            ),
+        };
+    } finally {
+        fclose($lock);
+        if (is_file($lockPath) && !is_link($lockPath)) {
+            @unlink($lockPath);
+        }
+    }
+}
+
+function chordsheetsDeployRespond(array $payload, int $status): never
+{
+    http_response_code($status);
+    header('Content-Type: application/json; charset=utf-8');
+    header('Cache-Control: no-store');
+    header('X-Content-Type-Options: nosniff');
+    header('X-Frame-Options: DENY');
+    echo json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    exit;
+}
+
+if (!defined('CHORDSHEETS_DEPLOY_TESTING')) {
+    try {
+        $https = strtolower((string) ($_SERVER['HTTPS'] ?? ''));
+        if (!in_array($https, ['on', '1'], true)) {
+            chordsheetsDeployFail('HTTPS is required.', 400);
+        }
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            chordsheetsDeployFail('Only POST is allowed.', 405);
+        }
+        $contentType = strtolower((string) ($_SERVER['CONTENT_TYPE'] ?? ''));
+        if (!str_starts_with($contentType, 'application/json')) {
+            chordsheetsDeployFail('Content type must be application/json.', 415);
+        }
+        $contentLength = (int) ($_SERVER['CONTENT_LENGTH'] ?? 0);
+        if ($contentLength < 1 || $contentLength > 4096) {
+            chordsheetsDeployFail('Request body size is invalid.', 413);
+        }
+        $rawBody = file_get_contents('php://input');
+        if (!is_string($rawBody) || strlen($rawBody) > 4096) {
+            chordsheetsDeployFail('Request body is invalid.');
+        }
+        $request = json_decode($rawBody, true, 16, JSON_THROW_ON_ERROR);
+        if (!is_array($request)) {
+            chordsheetsDeployFail('Request body is invalid.');
+        }
+        $signature = strtolower((string) ($_SERVER['HTTP_X_DEPLOY_SIGNATURE'] ?? ''));
+        $result = chordsheetsDeployExecute(
+            $request,
+            $signature,
+            (string) ($_SERVER['DOCUMENT_ROOT'] ?? ''),
+            __FILE__
+        );
+        if (in_array($result['state'] ?? '', ['committed', 'rolled_back'], true)
+            && is_file(__FILE__)) {
+            @unlink(__FILE__);
+        }
+        chordsheetsDeployRespond($result, 200);
+    } catch (ChordsheetsDeployException $exception) {
+        chordsheetsDeployRespond(
+            ['ok' => false, 'error' => $exception->getMessage()],
+            $exception->httpStatus
+        );
+    } catch (Throwable) {
+        chordsheetsDeployRespond(
+            ['ok' => false, 'error' => 'Unexpected deployment failure.'],
+            500
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- replace SSH/SCP deployment with explicit FTPS uploads and signed HTTPS activation
- upload the application as one verified ZIP plus a short-lived token and transient PHP runner
- validate ZIP paths, entry types, sizes, checksum, expansion ratio, and required files without shell execution
- activate releases through the current symlink and support signed commit/rollback
- preserve shared DokuWiki configuration and data

## Security
- per-run 256-bit HMAC secret and 128-bit random runner name
- five-minute request freshness and single-phase replay protection
- TLS verification required for FTPS and HTTPS
- no credentials in URLs or repository
- exact cleanup of runner, token, and archive

## Verification
- full real DokuWiki ZIP activation, commit, second activation, and rollback in PHP integration container
- invalid-signature rejection
- PowerShell deployment policy tests
- PHP syntax checks
- actionlint