### PR TITLE
Support Webgo FTP domain chroot

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -61,6 +61,7 @@ jobs:
           ./deployment/tests/zip-output.test.ps1
           ./deployment/tests/workflow-policy.test.ps1
           ./deployment/tests/php-web-deploy-policy.test.ps1
+          ./deployment/tests/webgo-chroot-policy.test.ps1
 
       - name: Test PHP web deployment and rollback
         shell: bash
@@ -113,15 +114,16 @@ jobs:
           nonce=$(openssl rand -hex 16)
           deploy_secret=$(openssl rand -hex 32)
           expires_at=$(($(date +%s) + 900))
-          runner_name=".deploy-$nonce.php"
+          runner_name="deploy-$nonce.php"
           archive_name=".release-$nonce.zip"
-          token_name=".deploy-$nonce.json"
+          token_name=".deploy-token-$nonce.php"
           runner_url="$DEMO_URL/$runner_name"
           ftp_base="ftp://$FTP_SERVER:$FTP_PORT"
           token_file="$RUNNER_TEMP/$token_name"
           request_file="$RUNNER_TEMP/deployment-request.json"
           response_file="$RUNNER_TEMP/deployment-response.json"
 
+          printf '%s\n' '<?php exit; __halt_compiler();' > "$token_file"
           jq -n \
             --arg nonce "$nonce" \
             --arg sha "$GITHUB_SHA" \
@@ -138,7 +140,7 @@ jobs:
               secret: $secret,
               expires_at: $expires_at,
               phase: "uploaded"
-            }' > "$token_file"
+            }' >> "$token_file"
 
           ftp_options=(
             --fail
@@ -219,16 +221,16 @@ jobs:
             if [[ "$deployment_may_be_active" -eq 1 ]]; then
               invoke_runner rollback rolled_back >/dev/null 2>&1
             fi
-            ftp_delete "/current/$runner_name"
-            ftp_delete "/uploads/$archive_name"
-            ftp_delete "/uploads/$token_name"
+            ftp_delete "/$runner_name"
+            ftp_delete "/$archive_name"
+            ftp_delete "/$token_name"
             exit "$status"
           }
           trap cleanup_deployment EXIT
 
-          ftp_upload "$release_archive" "/uploads/$archive_name"
-          ftp_upload "$runner_source" "/current/$runner_name"
-          ftp_upload "$token_file" "/uploads/$token_name"
+          ftp_upload "$release_archive" "/$archive_name"
+          ftp_upload "$runner_source" "/$runner_name"
+          ftp_upload "$token_file" "/$token_name"
 
           deployment_may_be_active=1
           invoke_runner deploy active

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -10,7 +10,7 @@ and users live in `shared/conf`.
 - PHP 8.3 or newer with the `ZipArchive` extension is selected for the domain.
 - A valid Let's Encrypt certificate is active and HTTP redirects to the same
   HTTPS hostname.
-- The additional Webgo FTP account is rooted at `/chordsheets-demo`.
+- The additional Webgo FTP account is rooted at `/chordsheets-demo/current`.
 - The FTP endpoint supports explicit TLS on port 21. The workflow refuses
   plaintext FTP and never disables certificate verification.
 
@@ -43,9 +43,10 @@ The workflow builds one verified `dokuwiki-chordsheets-demo.zip`. For each
 deployment it generates a 128-bit random runner name and a separate 256-bit
 HMAC secret. It uploads over explicit FTPS:
 
-1. the single application ZIP into `/uploads`;
-2. a short-lived authorization file outside the public document root;
-3. the generic PHP runner under a random name in `/current`.
+1. the single application ZIP under a random hidden name;
+2. a short-lived PHP authorization file that exits without returning its
+   contents when requested directly;
+3. the generic PHP runner under a separate random hidden name.
 
 The pipeline then calls the runner over HTTPS with a timestamped HMAC-signed
 JSON request. The secret is never placed in the URL or repository. Requests
@@ -74,7 +75,6 @@ The resulting layout is:
   shared/
     conf/
     data/
-  uploads/
 ```
 
 The setup boots DokuWiki without `install.php`, enables ACLs, disables

--- a/deployment/tests/web-deploy.integration.php
+++ b/deployment/tests/web-deploy.integration.php
@@ -53,7 +53,7 @@ function testWriteToken(
     string $archiveHash,
     string $secret
 ): string {
-    $tokenPath = "$root/uploads/.deploy-$nonce.json";
+    $tokenPath = "$root/current/.deploy-token-$nonce.php";
     $token = [
         'version' => 1,
         'nonce' => $nonce,
@@ -64,7 +64,7 @@ function testWriteToken(
         'expires_at' => time() + 600,
         'phase' => 'uploaded',
     ];
-    testAssert(file_put_contents($tokenPath, json_encode($token, JSON_THROW_ON_ERROR), LOCK_EX) !== false, 'Could not write token.');
+    testAssert(file_put_contents($tokenPath, CHORDSHEETS_DEPLOY_TOKEN_PREFIX . json_encode($token, JSON_THROW_ON_ERROR), LOCK_EX) !== false, 'Could not write token.');
     chmod($tokenPath, 0600);
     return $tokenPath;
 }
@@ -80,9 +80,7 @@ if (!class_exists(ZipArchive::class)) {
 
 $root = sys_get_temp_dir() . '/chordsheets-php-deploy-' . bin2hex(random_bytes(8));
 $current = "$root/current";
-$uploads = "$root/uploads";
 mkdir($current, 0700, true);
-mkdir($uploads, 0700, true);
 
 try {
     $runnerSource = realpath($argv[1] ?? __DIR__ . '/../web-deploy.php');
@@ -91,9 +89,9 @@ try {
     $nonce1 = str_repeat('1', 32);
     $sha1 = str_repeat('a', 40);
     $secret1 = str_repeat('b', 64);
-    $runnerName1 = ".deploy-$nonce1.php";
+    $runnerName1 = "deploy-$nonce1.php";
     $archiveName1 = ".release-$nonce1.zip";
-    $archivePath1 = "$uploads/$archiveName1";
+    $archivePath1 = "$current/$archiveName1";
     $archiveHash1 = testCreateArchive($archivePath1, 'release-one', $argv[2] ?? null);
     copy($runnerSource, "$current/$runnerName1");
     $tokenPath1 = testWriteToken($root, $nonce1, $sha1, $archiveName1, $archiveHash1, $secret1);
@@ -143,9 +141,9 @@ try {
     $nonce2 = str_repeat('2', 32);
     $sha2 = str_repeat('c', 40);
     $secret2 = str_repeat('d', 64);
-    $runnerName2 = ".deploy-$nonce2.php";
+    $runnerName2 = "deploy-$nonce2.php";
     $archiveName2 = ".release-$nonce2.zip";
-    $archivePath2 = "$uploads/$archiveName2";
+    $archivePath2 = "$current/$archiveName2";
     $archiveHash2 = testCreateArchive($archivePath2, 'release-two', $argv[2] ?? null);
     copy($runnerSource, "$current/$runnerName2");
     $tokenPath2 = testWriteToken($root, $nonce2, $sha2, $archiveName2, $archiveHash2, $secret2);

--- a/deployment/tests/webgo-chroot-policy.test.ps1
+++ b/deployment/tests/webgo-chroot-policy.test.ps1
@@ -1,0 +1,36 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$workflow = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml')
+$runner = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot 'deployment\web-deploy.php')
+
+foreach ($requiredWorkflowPattern in @(
+    'ftp_upload "\$release_archive" "/\$archive_name"',
+    'ftp_upload "\$runner_source" "/\$runner_name"',
+    'ftp_upload "\$token_file" "/\$token_name"',
+    'token_name="\.deploy-token-\$nonce\.php"',
+    'runner_name="deploy-\$nonce\.php"',
+    '<\?php exit; __halt_compiler\(\);'
+)) {
+    if ($workflow -notmatch $requiredWorkflowPattern) {
+        throw "Workflow is not compatible with the Webgo FTP chroot: $requiredWorkflowPattern"
+    }
+}
+
+if ($workflow -match 'ftp_upload [^\r\n]+"/current/') {
+    throw 'FTP uploads must not prepend /current inside the Webgo domain chroot.'
+}
+
+foreach ($requiredRunnerPattern in @(
+    'CHORDSHEETS_DEPLOY_TOKEN_PREFIX',
+    'basename\(\$tokenPath\)',
+    'copy\(\$tokenPath, "\$staging/\$tokenName"\)',
+    '\$documentRoot/\.deploy-token-\$nonce\.php'
+)) {
+    if ($runner -notmatch $requiredRunnerPattern) {
+        throw "Runner does not carry authorization across the atomic switch: $requiredRunnerPattern"
+    }
+}
+
+Write-Host 'webgo-chroot-policy.test.ps1: PASS'

--- a/deployment/tests/workflow-policy.test.ps1
+++ b/deployment/tests/workflow-policy.test.ps1
@@ -37,7 +37,7 @@ Assert-Match $workflow 'X-Deploy-Signature:' 'Deployment request must carry an H
 Assert-Match $workflow 'openssl dgst -sha256 -mac HMAC' 'Pipeline must compute the deployment HMAC locally.'
 Assert-Match $workflow 'deployment_may_be_active' 'Pipeline must track potentially active releases.'
 Assert-Match $workflow 'invoke_runner rollback rolled_back' 'Pipeline must roll back failed deployments.'
-Assert-Match $workflow 'ftp_delete "/current/\$runner_name"' 'Pipeline must clean up the transient PHP runner.'
+Assert-Match $workflow 'ftp_delete "/\$runner_name"' 'Pipeline must clean up the transient PHP runner.'
 Assert-Match $workflow 'dokuwiki-chordsheets-demo\.zip' 'Workflow must deploy one ZIP artifact.'
 Assert-NoMatch $workflow 'dokuwiki-chordsheets-demo\.tgz' 'Workflow must not deploy a tarball.'
 Assert-NoMatch $workflow 'sshpass|\bscp\b|StrictHostKeyChecking|UserKnownHostsFile' 'Workflow must not require an SSH shell.'

--- a/deployment/web-deploy.php
+++ b/deployment/web-deploy.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+const CHORDSHEETS_DEPLOY_TOKEN_PREFIX = "<?php exit; __halt_compiler();\n";
+
 final class ChordsheetsDeployException extends RuntimeException
 {
     public function __construct(string $message, public readonly int $httpStatus = 400)
@@ -67,8 +69,18 @@ function chordsheetsDeployReadToken(string $tokenPath): array
     if (!is_int($size) || $size < 1 || $size > 4096) {
         chordsheetsDeployFail('Deployment authorization is invalid.', 403);
     }
+    $contents = file_get_contents($tokenPath);
+    if (!is_string($contents)
+        || !str_starts_with($contents, CHORDSHEETS_DEPLOY_TOKEN_PREFIX)) {
+        chordsheetsDeployFail('Deployment authorization is invalid.', 403);
+    }
     try {
-        $token = json_decode((string) file_get_contents($tokenPath), true, 16, JSON_THROW_ON_ERROR);
+        $token = json_decode(
+            substr($contents, strlen(CHORDSHEETS_DEPLOY_TOKEN_PREFIX)),
+            true,
+            16,
+            JSON_THROW_ON_ERROR
+        );
     } catch (JsonException) {
         chordsheetsDeployFail('Deployment authorization is invalid.', 403);
     }
@@ -82,7 +94,8 @@ function chordsheetsDeploySaveToken(string $tokenPath, array $token): void
 {
     chordsheetsDeployWriteFile(
         $tokenPath,
-        json_encode($token, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+        CHORDSHEETS_DEPLOY_TOKEN_PREFIX
+        . json_encode($token, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
         0600
     );
 }
@@ -361,16 +374,20 @@ function chordsheetsDeployActivate(
 ): array {
     $sha = $token['sha'];
     $nonce = $token['nonce'];
-    $archivePath = "$root/uploads/{$token['archive']}";
+    $archivePath = "$documentRoot/{$token['archive']}";
     $releases = "$root/releases";
     $release = "$releases/$sha";
     $staging = "$releases/.$sha.$nonce.tmp";
     $holder = "$root/.previous-$nonce";
     $next = "$root/current.next-$nonce";
     $runnerName = basename($scriptPath);
+    $tokenName = basename($tokenPath);
 
-    if (!preg_match('/^\.deploy-' . preg_quote($nonce, '/') . '\.php$/D', $runnerName)) {
+    if (!preg_match('/^deploy-' . preg_quote($nonce, '/') . '\.php$/D', $runnerName)) {
         chordsheetsDeployFail('Deployment runner name is invalid.', 400);
+    }
+    if ($tokenName !== ".deploy-token-$nonce.php") {
+        chordsheetsDeployFail('Deployment token name is invalid.', 400);
     }
     chordsheetsDeployValidateArchive($archivePath, $token['archive_sha256']);
     if (!is_dir($releases) && !mkdir($releases, 0755, true)) {
@@ -414,6 +431,10 @@ function chordsheetsDeployActivate(
         }
         chmod("$staging/$runnerName", 0600);
         if (!rename($staging, $release)) {
+        if (!copy($tokenPath, "$staging/$tokenName")) {
+            chordsheetsDeployFail('Could not stage deployment authorization.', 500);
+        }
+        chmod("$staging/$tokenName", 0600);
             chordsheetsDeployFail('Could not finalize release staging.', 500);
         }
 
@@ -484,13 +505,15 @@ function chordsheetsDeployFinish(
     $sha = $token['sha'];
     $runnerName = $token['runner'] ?? '';
     $holderName = $token['holder'] ?? '';
+    $tokenName = basename($tokenPath);
     if ($runnerName !== basename($scriptPath)
-        || !preg_match('/^\.deploy-' . preg_quote($nonce, '/') . '\.php$/D', $runnerName)
-        || $holderName !== ".previous-$nonce") {
+        || !preg_match('/^deploy-' . preg_quote($nonce, '/') . '\.php$/D', $runnerName)
+        || $holderName !== ".previous-$nonce"
+        || $tokenName !== ".deploy-token-$nonce.php") {
         chordsheetsDeployFail('Deployment state is invalid.', 500);
     }
     $holder = "$root/$holderName";
-    $archivePath = "$root/uploads/{$token['archive']}";
+    $archivePath = "$holder/{$token['archive']}";
     $release = "$root/releases/$sha";
     if (!is_link($documentRoot) || readlink($documentRoot) !== "releases/$sha") {
         chordsheetsDeployFail('Active deployment does not match the request.', 409);
@@ -508,8 +531,8 @@ function chordsheetsDeployFinish(
         }
         @unlink($failedLink);
         @unlink("$documentRoot/$runnerName");
-        @unlink($archivePath);
-        @unlink($tokenPath);
+        @unlink("$documentRoot/$tokenName");
+        @unlink("$documentRoot/{$token['archive']}");
         if (is_dir($release) && !is_link($release)) {
             chordsheetsDeployRemoveTree($release);
         }
@@ -519,6 +542,8 @@ function chordsheetsDeployFinish(
     @unlink("$holder/$runnerName");
     if (($token['previous_kind'] ?? null) === 'symlink') {
         $previous = "$root/previous";
+    @unlink("$holder/$tokenName");
+    @unlink($archivePath);
         if (file_exists($previous) && !is_link($previous)) {
             chordsheetsDeployFail('Previous deployment pointer is unsafe.', 500);
         }
@@ -529,7 +554,6 @@ function chordsheetsDeployFinish(
             chordsheetsDeployFail('Could not retain previous deployment pointer.', 500);
         }
     }
-    @unlink($archivePath);
     @unlink($tokenPath);
     @unlink($scriptPath);
     return ['ok' => true, 'state' => 'committed', 'release' => $sha];
@@ -553,7 +577,7 @@ function chordsheetsDeployExecute(
     if (!is_string($nonce) || !preg_match('/^[a-f0-9]{32}$/D', $nonce)) {
         chordsheetsDeployFail('Invalid deployment request.');
     }
-    $tokenPath = "$root/uploads/.deploy-$nonce.json";
+    $tokenPath = "$documentRoot/.deploy-token-$nonce.php";
     $token = chordsheetsDeployReadToken($tokenPath);
     chordsheetsDeployValidateAuthorization($request, $signature, $token);
 


### PR DESCRIPTION
## Summary
- upload transient deployment files directly into the FTP account domain root
- use a public random runner filename compatible with Webgo dotfile restrictions
- carry authorization across the atomic release switch in a PHP token that exits without exposing its contents
- clean runner, token, and ZIP from the exact active or previous document root
- add a Webgo chroot regression policy test

## Verification
- full real DokuWiki ZIP activation, commit, second activation, and rollback
- PHP syntax and deployment policy tests
- actionlint
- git diff --check