### PR TITLE
fix: detect Webgo FTP document root

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -62,6 +62,7 @@ jobs:
           ./deployment/tests/workflow-policy.test.ps1
           ./deployment/tests/php-web-deploy-policy.test.ps1
           ./deployment/tests/webgo-chroot-policy.test.ps1
+          ./deployment/tests/webroot-discovery-policy.test.ps1
 
       - name: Test PHP web deployment and rollback
         shell: bash
@@ -119,10 +120,17 @@ jobs:
           token_name=".deploy-token-$nonce.php"
           runner_url="$DEMO_URL/$runner_name"
           ftp_base="ftp://$FTP_SERVER:$FTP_PORT"
+          probe_name="deploy-probe-$nonce.txt"
+          probe_file="$RUNNER_TEMP/$probe_name"
+          probe_remote_path=''
+          ftp_web_root=''
+          web_root_found=0
+          web_root_candidates=('' '/current' '/chordsheets-demo/current')
           token_file="$RUNNER_TEMP/$token_name"
           request_file="$RUNNER_TEMP/deployment-request.json"
           response_file="$RUNNER_TEMP/deployment-response.json"
 
+          printf '%s' "$nonce" > "$probe_file"
           printf '%s\n' '<?php exit; __halt_compiler();' > "$token_file"
           jq -n \
             --arg nonce "$nonce" \
@@ -155,7 +163,6 @@ jobs:
             local source_file=$1
             local target_path=$2
             curl "${ftp_options[@]}" \
-              --ftp-create-dirs \
               --upload-file "$source_file" \
               "$ftp_base$target_path"
           }
@@ -169,6 +176,11 @@ jobs:
               "$ftp_base/" >/dev/null 2>&1; then
               return 0
             fi
+          }
+
+          ftp_path() {
+            local name=$1
+            printf '%s/%s' "$ftp_web_root" "$name"
           }
 
           invoke_runner() {
@@ -221,16 +233,55 @@ jobs:
             if [[ "$deployment_may_be_active" -eq 1 ]]; then
               invoke_runner rollback rolled_back >/dev/null 2>&1
             fi
-            ftp_delete "/$runner_name"
-            ftp_delete "/$archive_name"
-            ftp_delete "/$token_name"
+            if [[ -n "$probe_remote_path" ]]; then
+              ftp_delete "$probe_remote_path"
+            fi
+            if [[ "$web_root_found" -eq 1 ]]; then
+              ftp_delete "$(ftp_path "$runner_name")"
+              ftp_delete "$(ftp_path "$archive_name")"
+              ftp_delete "$(ftp_path "$token_name")"
+            fi
             exit "$status"
           }
           trap cleanup_deployment EXIT
 
-          ftp_upload "$release_archive" "/$archive_name"
-          ftp_upload "$runner_source" "/$runner_name"
-          ftp_upload "$token_file" "/$token_name"
+          for candidate in "${web_root_candidates[@]}"; do
+            probe_remote_path="$candidate/$probe_name"
+            if ! ftp_upload "$probe_file" "$candidate/$probe_name"; then
+              ftp_delete "$candidate/$probe_name"
+              probe_remote_path=''
+              continue
+            fi
+
+            probe_response=''
+            if probe_response=$(curl --fail --silent --show-error \
+              --proto '=https' --tlsv1.2 \
+              --header 'Cache-Control: no-cache' \
+              --max-time 15 \
+              "$DEMO_URL/$probe_name"); then
+              if [[ "$probe_response" == "$nonce" ]]; then
+                ftp_web_root=$candidate
+                web_root_found=1
+                ftp_delete "$candidate/$probe_name"
+                probe_remote_path=''
+                break
+              fi
+            fi
+
+            ftp_delete "$candidate/$probe_name"
+            probe_remote_path=''
+          done
+
+          if [[ "$web_root_found" -ne 1 ]]; then
+            echo 'Could not map the FTP account to the HTTPS document root.' >&2
+            exit 1
+          fi
+
+          echo "Detected FTP web root: ${ftp_web_root:-/}"
+
+          ftp_upload "$release_archive" "$(ftp_path "$archive_name")"
+          ftp_upload "$runner_source" "$(ftp_path "$runner_name")"
+          ftp_upload "$token_file" "$(ftp_path "$token_name")"
 
           deployment_may_be_active=1
           invoke_runner deploy active

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -10,7 +10,9 @@ and users live in `shared/conf`.
 - PHP 8.3 or newer with the `ZipArchive` extension is selected for the domain.
 - A valid Let's Encrypt certificate is active and HTTP redirects to the same
   HTTPS hostname.
-- The additional Webgo FTP account is rooted at `/chordsheets-demo/current`.
+- The additional Webgo FTP account can reach the domain document root. The
+  workflow locates it from a fixed allowlist using a random text probe and
+  removes the probe immediately.
 - The FTP endpoint supports explicit TLS on port 21. The workflow refuses
   plaintext FTP and never disables certificate verification.
 
@@ -46,7 +48,7 @@ HMAC secret. It uploads over explicit FTPS:
 1. the single application ZIP under a random hidden name;
 2. a short-lived PHP authorization file that exits without returning its
    contents when requested directly;
-3. the generic PHP runner under a separate random hidden name.
+3. the generic PHP runner under a separate random name.
 
 The pipeline then calls the runner over HTTPS with a timestamped HMAC-signed
 JSON request. The secret is never placed in the URL or repository. Requests
@@ -90,6 +92,8 @@ Local checks:
 ./deployment/tests/zip-output.test.ps1
 ./deployment/tests/workflow-policy.test.ps1
 ./deployment/tests/php-web-deploy-policy.test.ps1
+./deployment/tests/webgo-chroot-policy.test.ps1
+./deployment/tests/webroot-discovery-policy.test.ps1
 docker run --rm `
   -v "${PWD}/deployment:/repo/deployment:ro" `
   composer:2@sha256:f0809732b2188154b3faa8e44ab900595acb0b09cd0aa6c34e798efe4ebc9021 `

--- a/deployment/tests/webgo-chroot-policy.test.ps1
+++ b/deployment/tests/webgo-chroot-policy.test.ps1
@@ -6,9 +6,10 @@ $workflow = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot '.github\wo
 $runner = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot 'deployment\web-deploy.php')
 
 foreach ($requiredWorkflowPattern in @(
-    'ftp_upload "\$release_archive" "/\$archive_name"',
-    'ftp_upload "\$runner_source" "/\$runner_name"',
-    'ftp_upload "\$token_file" "/\$token_name"',
+    'ftp_upload "\$release_archive" "\$\(ftp_path "\$archive_name"\)"',
+    'ftp_upload "\$runner_source" "\$\(ftp_path "\$runner_name"\)"',
+    'ftp_upload "\$token_file" "\$\(ftp_path "\$token_name"\)"',
+    'printf ''%s/%s'' "\$ftp_web_root" "\$name"',
     'token_name="\.deploy-token-\$nonce\.php"',
     'runner_name="deploy-\$nonce\.php"',
     '<\?php exit; __halt_compiler\(\);'
@@ -16,10 +17,6 @@ foreach ($requiredWorkflowPattern in @(
     if ($workflow -notmatch $requiredWorkflowPattern) {
         throw "Workflow is not compatible with the Webgo FTP chroot: $requiredWorkflowPattern"
     }
-}
-
-if ($workflow -match 'ftp_upload [^\r\n]+"/current/') {
-    throw 'FTP uploads must not prepend /current inside the Webgo domain chroot.'
 }
 
 foreach ($requiredRunnerPattern in @(

--- a/deployment/tests/webroot-discovery-policy.test.ps1
+++ b/deployment/tests/webroot-discovery-policy.test.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$workflow = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml')
+
+foreach ($requiredPattern in @(
+    'web_root_candidates=\(',
+    "'' '/current' '/chordsheets-demo/current'",
+    'probe_name="deploy-probe-\$nonce\.txt"',
+    'printf ''%s'' "\$nonce" > "\$probe_file"',
+    'ftp_upload "\$probe_file" "\$candidate/\$probe_name"',
+    'curl --fail --silent --show-error',
+    '"\$DEMO_URL/\$probe_name"',
+    '\[\[ "\$probe_response" == "\$nonce" \]\]',
+    'ftp_delete "\$candidate/\$probe_name"',
+    'ftp_web_root=\$candidate'
+)) {
+    if ($workflow -notmatch $requiredPattern) {
+        throw "Workflow is missing safe web-root discovery: $requiredPattern"
+    }
+}
+
+if ($workflow -match '--ftp-create-dirs') {
+    throw 'Web-root discovery must not create candidate directories.'
+}
+
+if ($workflow -match '(?m)^\s*(?:curl|ftp_upload).*(?:LIST|--list-only).*(?:\$ftp_base|FTP_SERVER)') {
+    throw 'Web-root discovery must not expose a remote directory listing.'
+}
+
+Write-Host 'webroot-discovery-policy.test.ps1: PASS'

--- a/deployment/tests/workflow-policy.test.ps1
+++ b/deployment/tests/workflow-policy.test.ps1
@@ -37,7 +37,7 @@ Assert-Match $workflow 'X-Deploy-Signature:' 'Deployment request must carry an H
 Assert-Match $workflow 'openssl dgst -sha256 -mac HMAC' 'Pipeline must compute the deployment HMAC locally.'
 Assert-Match $workflow 'deployment_may_be_active' 'Pipeline must track potentially active releases.'
 Assert-Match $workflow 'invoke_runner rollback rolled_back' 'Pipeline must roll back failed deployments.'
-Assert-Match $workflow 'ftp_delete "/\$runner_name"' 'Pipeline must clean up the transient PHP runner.'
+Assert-Match $workflow 'ftp_delete "\$\(ftp_path "\$runner_name"\)"' 'Pipeline must clean up the transient PHP runner.'
 Assert-Match $workflow 'dokuwiki-chordsheets-demo\.zip' 'Workflow must deploy one ZIP artifact.'
 Assert-NoMatch $workflow 'dokuwiki-chordsheets-demo\.tgz' 'Workflow must not deploy a tarball.'
 Assert-NoMatch $workflow 'sshpass|\bscp\b|StrictHostKeyChecking|UserKnownHostsFile' 'Workflow must not require an SSH shell.'
@@ -46,8 +46,8 @@ Assert-NoMatch $workflow '--insecure|-k(?:\s|$)' 'TLS verification must never be
 Assert-NoMatch $workflow '\|\|\s*true' 'Deployment or rollback failures must not be ignored.'
 
 $uploadCount = [regex]::Matches($workflow, 'ftp_upload\s+"').Count
-if ($uploadCount -ne 3) {
-    throw "Workflow must upload one ZIP plus one token and one runner, found $uploadCount uploads."
+if ($uploadCount -ne 4) {
+    throw "Workflow must upload one probe, one ZIP, one token and one runner, found $uploadCount uploads."
 }
 
 $secretReferences = [regex]::Matches($workflow, 'secrets\.([A-Z0-9_]+)') |


### PR DESCRIPTION
Adds a safe fixed-allowlist document-root probe before deployment, cleans every probe and transient artifact, and keeps FTPS plus HTTPS certificate verification enabled. Updates deployment documentation and policy tests. Verified locally with all deployment policy tests, actionlint, and the full PHP ZIP deployment integration test.