### PR TITLE
fix: use configured Webgo deployment path

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -93,6 +93,7 @@ jobs:
           FTP_SERVER: ${{ secrets.FTP_SERVER }}
           FTP_USERNAME: ${{ secrets.FTP_USERNAME }}
           FTP_PORT: ${{ vars.FTP_PORT }}
+          FTP_REMOTE_PATH: ${{ vars.FTP_REMOTE_PATH }}
           DEMO_URL: ${{ vars.DEMO_URL }}
         run: |
           set -euo pipefail
@@ -101,12 +102,14 @@ jobs:
           : "${FTP_PASSWORD:?FTP_PASSWORD is required}"
           : "${FTP_SERVER:?FTP_SERVER is required}"
           : "${FTP_USERNAME:?FTP_USERNAME is required}"
+          : "${FTP_REMOTE_PATH:?FTP_REMOTE_PATH is required}"
           : "${DEMO_URL:?DEMO_URL is required}"
 
           FTP_PORT=${FTP_PORT:-21}
           [[ "$FTP_PORT" == '21' ]]
           [[ "$FTP_SERVER" =~ ^[A-Za-z0-9.-]+$ ]]
           [[ "$FTP_USERNAME" =~ ^[A-Za-z0-9._-]+$ ]]
+          [[ "$FTP_REMOTE_PATH" == '/home/www/chordsheets-demo' ]]
           [[ "$DEMO_URL" == 'https://chordsheets.pazureck.de' ]]
 
           release_archive="$RUNNER_TEMP/dokuwiki-chordsheets-demo.zip"
@@ -125,7 +128,7 @@ jobs:
           probe_remote_path=''
           ftp_web_root=''
           web_root_found=0
-          web_root_candidates=('' '/current' '/chordsheets-demo/current')
+          web_root_candidates=('' '/current' '/chordsheets-demo/current' "$FTP_REMOTE_PATH/current")
           token_file="$RUNNER_TEMP/$token_name"
           request_file="$RUNNER_TEMP/deployment-request.json"
           response_file="$RUNNER_TEMP/deployment-response.json"

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -33,6 +33,7 @@ Environment secrets:
 Environment variables:
 
 - `FTP_PORT=21`
+- `FTP_REMOTE_PATH=/home/www/chordsheets-demo`
 - `DEMO_URL=https://chordsheets.pazureck.de`
 
 The environment is restricted to the `master` branch. The workflow can only be

--- a/deployment/tests/webroot-discovery-policy.test.ps1
+++ b/deployment/tests/webroot-discovery-policy.test.ps1
@@ -5,8 +5,11 @@ $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $workflow = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot '.github\workflows\demo-deploy.yml')
 
 foreach ($requiredPattern in @(
+    'FTP_REMOTE_PATH: \$\{\{ vars\.FTP_REMOTE_PATH \}\}',
+    'FTP_REMOTE_PATH is required',
+    '\[\[ "\$FTP_REMOTE_PATH" == ''/home/www/chordsheets-demo'' \]\]',
     'web_root_candidates=\(',
-    "'' '/current' '/chordsheets-demo/current'",
+    'web_root_candidates=.*"\$FTP_REMOTE_PATH/current"',
     'probe_name="deploy-probe-\$nonce\.txt"',
     'printf ''%s'' "\$nonce" > "\$probe_file"',
     'ftp_upload "\$probe_file" "\$candidate/\$probe_name"',


### PR DESCRIPTION
Adds the existing demo environment variable FTP_REMOTE_PATH as a strictly validated web-root candidate. This preserves the safe random probe and all cleanup behavior while covering Webgo's canonical /home/www/chordsheets-demo/current path. Policy tests and actionlint pass.