### PR TITLE
feat: add per-sheet source tabs to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ expose validated state through `data-transpose`, `data-instrument`,
 `data-tooltips`, `data-tooltip-behavior`, `data-section-style`,
 and `data-export-metadata` for themes and export tools.
 
+Add `source="tabs"` to an opening tag when an example should let readers
+switch between the rendered **Ansicht** and its copyable DokuWiki **Source**.
+This is opt-in, so existing chord sheets keep their current output without
+additional controls.
+
 ## Inline chords, tablature, and notation
 
 Slash chords such as `G/B` also expose the bass through `data-bass-note` and

--- a/_test/script.test.js
+++ b/_test/script.test.js
@@ -1304,6 +1304,152 @@ function createScope(songs, chords = []) {
     };
 }
 
+function createSourceTabsFixture() {
+    const listeners = Object.create(null);
+    const panels = {
+        "example-view-panel": { hidden: false, id: "example-view-panel" },
+        "example-source-panel": { hidden: true, id: "example-source-panel" }
+    };
+    const foreignPanels = {
+        "example-view-panel": { hidden: false, id: "example-view-panel" },
+        "example-source-panel": { hidden: true, id: "example-source-panel" }
+    };
+    const document = {
+        addEventListener() {},
+        getElementById(id) {
+            return foreignPanels[id] || null;
+        }
+    };
+    const makeTab = (name, panelId, selected) => {
+        const attributes = {
+            "aria-controls": panelId,
+            "aria-selected": selected ? "true" : "false",
+            tabindex: selected ? "0" : "-1"
+        };
+        return {
+            ownerDocument: document,
+            focused: false,
+            addEventListener(type, listener) {
+                listeners[name + ":" + type] = listener;
+            },
+            getAttribute(attributeName) {
+                return attributes[attributeName];
+            },
+            setAttribute(attributeName, value) {
+                attributes[attributeName] = String(value);
+            },
+            focus() {
+                this.focused = true;
+            }
+        };
+    };
+    const viewTab = makeTab("view", "example-view-panel", true);
+    const sourceTab = makeTab("source", "example-source-panel", false);
+    const wrapper = {
+        querySelectorAll(selector) {
+            return selector === '[role="tabpanel"]' ? Object.values(panels) : [];
+        }
+    };
+    const tablist = {
+        closest(selector) {
+            return selector === ".chord-sheet-example" ? wrapper : null;
+        },
+        querySelectorAll(selector) {
+            return selector === '[role="tab"]' ? [viewTab, sourceTab] : [];
+        }
+    };
+    const root = {
+        querySelectorAll(selector) {
+            return selector === ".chord-sheet-example-tabs" ? [tablist] : [];
+        }
+    };
+    return { document, foreignPanels, listeners, panels, root, sourceTab, tablist, viewTab };
+}
+
+test("switches demo source tabs by click and keyboard without duplicate bindings", () => {
+    const fixture = createSourceTabsFixture();
+    const context = loadScript({ document: fixture.document });
+
+    assert.equal(context.initializeChordSheetSourceTabs(fixture.root), 1);
+    fixture.panels["example-view-panel"].hidden = true;
+    fixture.panels["example-source-panel"].hidden = false;
+    assert.equal(context.initializeChordSheetSourceTabs(fixture.root), 0);
+    assert.equal(fixture.panels["example-view-panel"].hidden, false);
+    assert.equal(fixture.panels["example-source-panel"].hidden, true);
+
+    fixture.listeners["source:click"]({ currentTarget: fixture.sourceTab });
+    assert.equal(fixture.sourceTab.getAttribute("aria-selected"), "true");
+    assert.equal(fixture.viewTab.getAttribute("aria-selected"), "false");
+    assert.equal(fixture.panels["example-source-panel"].hidden, false);
+    assert.equal(fixture.panels["example-view-panel"].hidden, true);
+
+    assert.equal(fixture.foreignPanels["example-source-panel"].hidden, true);
+    assert.equal(fixture.foreignPanels["example-view-panel"].hidden, false);
+    let prevented = false;
+    fixture.listeners["source:keydown"]({
+        currentTarget: fixture.sourceTab,
+        key: "ArrowLeft",
+        preventDefault() {
+            prevented = true;
+        }
+    });
+    assert.equal(prevented, true);
+    assert.equal(fixture.viewTab.focused, true);
+    assert.equal(fixture.viewTab.getAttribute("aria-selected"), "true");
+    assert.equal(fixture.panels["example-view-panel"].hidden, false);
+});
+
+test("re-applies demo fragment navigation after late page layout", () => {
+    const scrollCalls = [];
+    const target = {
+        scrollIntoView(options) {
+            scrollCalls.push(options);
+        }
+    };
+    const document = {
+        addEventListener() {},
+        getElementById(id) {
+            return id === "inline_chords_and_slash_bass" ? target : null;
+        },
+        querySelectorAll(selector) {
+            return selector === ".chord-sheet-example-tabs" ? [{}] : [];
+        }
+    };
+    const window = {
+        location: { hash: "#inline_chords_and_slash_bass" },
+        addEventListener() {}
+    };
+    const context = loadScript({ document, window });
+
+    assert.equal(context.restoreChordSheetHashTarget(), true);
+    assert.equal(scrollCalls.length, 1);
+    assert.equal(scrollCalls[0].block, "start");
+});
+
+test("only reinitializes and restores fragments for persisted pageshow events", () => {
+    const context = loadScript({
+        document: { addEventListener() {} },
+        window: { addEventListener() {} }
+    });
+    let readyCalls = 0;
+    let restoreCalls = 0;
+    context.ready = () => {
+        readyCalls += 1;
+    };
+    context.restoreChordSheetHashTarget = () => {
+        restoreCalls += 1;
+        return true;
+    };
+
+    assert.equal(context.initializeRestoredChordSheetPage({ persisted: false }), false);
+    assert.equal(readyCalls, 0);
+    assert.equal(restoreCalls, 0);
+
+    assert.equal(context.initializeRestoredChordSheetPage({ persisted: true }), true);
+    assert.equal(readyCalls, 1);
+    assert.equal(restoreCalls, 1);
+});
+
 test("initializes initial and AJAX-replaced sheets idempotently without duplicate listeners", () => {
     const documentListeners = Object.create(null);
     const windowListenerCounts = Object.create(null);
@@ -1335,6 +1481,8 @@ test("initializes initial and AJAX-replaced sheets idempotently without duplicat
 
     assert.equal(typeof documentListeners.DOMContentLoaded, "function");
     assert.equal(typeof documentListeners.dw_page_loaded, "function");
+    assert.equal(windowListenerCounts.pageshow, 1);
+    assert.equal(windowListenerCounts.load, 1);
 
     documentListeners.DOMContentLoaded();
     const initiallyRendered = firstSong.innerHTML;

--- a/_test/style-docs.test.js
+++ b/_test/style-docs.test.js
@@ -55,7 +55,7 @@ test("declares and consumes the public chord-sheet CSS custom properties", () =>
 test("keeps the native settings color picker rule self-contained", () => {
     assert.match(
         css,
-        /\.chordsheets-color-picker\s*\{[^}]*width:\s*2\.75rem;\s*\}\s*\.song-with-chords\s*\{/s
+        /\.chordsheets-color-picker\s*\{[^}]*width:\s*2\.75rem;\s*\}/s
     );
 });
 
@@ -135,6 +135,7 @@ test("documents supported syntax and configuration", () => {
         'author="',
         'date="',
         'instrument="ukulele"',
+        'source="tabs"',
         '{{tab}}',
         '--cs-chord-color',
         '@{x,3,2,0,1,0}'
@@ -151,6 +152,29 @@ test("documents supported syntax and configuration", () => {
     assert.match(demo, /instrument="ukulele"/);
     assert.match(demo, /\{\{tab\}\}/);
     assert.match(demo, /C@\{x,3,2,0,1,0\}/);
+});
+
+test("gives every live demo chord sheet an accessible view and source switch", () => {
+    const openingTags = liveDemo.match(/<chordSheet\b[^>]*>/gi) || [];
+    assert.ok(openingTags.length > 0, "Demo must contain live chord-sheet examples");
+    for (const openingTag of openingTags) {
+        assert.match(openingTag, /\bsource="tabs"/i, "Missing source tabs on " + openingTag);
+    }
+    assert.match(css, /\.chord-sheet-example-tabs\s*\{[\s\S]*?display:\s*flex/);
+    assert.match(css, /\.chord-sheet-example-tab\[aria-selected=["']true["']\]/);
+    assert.match(css, /\.chord-sheet-example-tab:focus-visible/);
+    assert.match(css, /\.chord-sheet-example-source\s+pre\s*\{[\s\S]*?overflow-x:\s*auto/);
+});
+
+test("visually scopes each source switch to one chord sheet card", () => {
+    const cardRule = css.match(/\.chord-sheet-example\s*\{([^}]*)\}/)?.[1] || "";
+    const tabsRule = css.match(/\.chord-sheet-example-tabs\s*\{([^}]*)\}/)?.[1] || "";
+
+    assert.match(cardRule, /border:\s*1px solid/);
+    assert.match(cardRule, /border-radius:/);
+    assert.match(cardRule, /background:/);
+    assert.match(tabsRule, /width:\s*fit-content/);
+    assert.doesNotMatch(tabsRule, /border-bottom:/);
 });
 
 test("keeps inline syntax examples from opening a live chord-sheet block", () => {
@@ -175,10 +199,30 @@ test("presents the completed wishlist as an interactive demo tour", () => {
     assert.match(liveDemo, /\{\{notation\}\}/);
 });
 
+test("shows how to switch the same progression from guitar to ukulele", () => {
+    assert.match(
+        demo,
+        /<code html>\s*<chordSheet 0[^>]*instrument="ukulele"[^>]*>\s*\[Progression\]\s*C\s+Am\s+F\s+G\s*<\/chordSheet>\s*<\/code>/
+    );
+    const sectionMatch = liveDemo.match(
+        /==== Ukulele and song metadata ====[\s\S]*?==== Standalone JTab chord ====/
+    );
+    assert.ok(sectionMatch, "Demo must contain the ukulele switch section");
+
+    const section = sectionMatch[0];
+    const openingTags = section.match(/<chordSheet 0[^>]*>/g) || [];
+    assert.equal(openingTags.length, 2);
+    assert.doesNotMatch(openingTags[0], /instrument=/);
+    assert.match(openingTags[1], /instrument="ukulele"/);
+    assert.match(openingTags[1], /author="[^"]+"/);
+    assert.match(openingTags[1], /date="\d{4}-\d{2}-\d{2}"/);
+    assert.equal((section.match(/C\s+Am\s+F\s+G/g) || []).length, 2);
+});
+
 test("includes a live standalone legacy JTab chord", () => {
     assert.match(
         liveDemo,
-        /==== Standalone JTab chord ====\s*<chordSheet 0>\s*%7\/2\.X\/X\.7\/3\.7\/4\.6\/1\.X\/X\[Bm7b5\]\s*<\/chordSheet>\s*The original JTab custom-chord syntax[\s\S]*?==== Tablature and standard notation ====/
+        /==== Standalone JTab chord ====\s*<chordSheet 0[^>]*>\s*%7\/2\.X\/X\.7\/3\.7\/4\.6\/1\.X\/X\[Bm7b5\]\s*<\/chordSheet>\s*The original JTab custom-chord syntax[\s\S]*?==== Tablature and standard notation ====/
     );
 });
 

--- a/_test/syntax-config-metadata.test.php
+++ b/_test/syntax-config-metadata.test.php
@@ -79,6 +79,47 @@ try {
     csAssertSame(array(), $plugin->getAllowedTypes(), 'Chord-sheet content must remain raw and must not activate nested wiki syntax.');
     csAssertSame('block', $plugin->getPType(), 'Chord sheets emit block-level article markup.');
 
+    $sourceTabs = $plugin->handle(
+        '<chordSheet 0 source="tabs" title="Source example">',
+        DOKU_LEXER_ENTER,
+        0,
+        $handler
+    );
+    csAssertSame(true, $sourceTabs[1]['source_tabs'], 'Source tabs must be opt-in through source="tabs".');
+    $invalidSourceTabs = $plugin->handle(
+        '<chordSheet 0 source="tabs-and-script">',
+        DOKU_LEXER_ENTER,
+        0,
+        $handler
+    );
+    csAssertSame(false, $invalidSourceTabs[1]['source_tabs'], 'Unknown source modes must not enable controls.');
+
+    $sourceRenderer = new Doku_Renderer();
+    $plugin->render('xhtml', $sourceRenderer, $sourceTabs);
+    $plugin->render('xhtml', $sourceRenderer, array(DOKU_LEXER_UNMATCHED, "[Verse]\nC & <unsafe>"));
+    $plugin->render('xhtml', $sourceRenderer, array(DOKU_LEXER_MATCHED, '%0/1.2/2.2/3.1/1.0/0.0/0[C]'));
+    $plugin->render('xhtml', $sourceRenderer, array(DOKU_LEXER_EXIT, ''));
+    csAssertContains('role="tablist"', $sourceRenderer->doc, 'Opt-in examples must render an accessible tab list.');
+    csAssertContains('role="tab"', $sourceRenderer->doc, 'View choices must use tab semantics.');
+    csAssertContains('aria-selected="true"', $sourceRenderer->doc, 'The rendered view must be selected initially.');
+    csAssertContains('role="tabpanel"', $sourceRenderer->doc, 'Both example views must use tab-panel semantics.');
+    csAssertContains('>Ansicht</button>', $sourceRenderer->doc, 'The rendered example tab must be clearly labelled.');
+    csAssertContains('>Source</button>', $sourceRenderer->doc, 'The source example tab must be clearly labelled.');
+    csAssertContains(
+        '&lt;chordSheet 0 source=&quot;tabs&quot; title=&quot;Source example&quot;&gt;',
+        $sourceRenderer->doc,
+        'The opening DokuWiki tag must be displayed as escaped source.'
+    );
+    csAssertContains('C &amp; &lt;unsafe&gt;', $sourceRenderer->doc, 'Source text must be escaped against HTML injection.');
+    csAssertContains('&lt;/chordSheet&gt;', $sourceRenderer->doc, 'The closing DokuWiki tag must be included in source.');
+    csAssertContains('%0/1.2/2.2/3.1/1.0/0.0/0[C]', $sourceRenderer->doc, 'Matched JTab source must remain copyable.');
+
+    $plainRenderer = new Doku_Renderer();
+    $plugin->render('xhtml', $plainRenderer, $legacy);
+    $plugin->render('xhtml', $plainRenderer, array(DOKU_LEXER_UNMATCHED, 'C'));
+    $plugin->render('xhtml', $plainRenderer, array(DOKU_LEXER_EXIT, ''));
+    csAssertNotContains('role="tablist"', $plainRenderer->doc, 'Existing chord sheets must stay unchanged by default.');
+
     $valid = $plugin->handle(
         '<chordSheet -2 title="Rock &amp; Roll" author="A &quot;B&quot;" date="2026-07-30">',
         DOKU_LEXER_ENTER,

--- a/demo/start.txt
+++ b/demo/start.txt
@@ -30,7 +30,7 @@ These short examples use original demo lyrics. Try the highlighted chords and co
 
 ==== Example 1 — A simple campfire progression ====
 
-<chordSheet 0>
+<chordSheet 0 source="tabs">
 [Intro]
 Am    F     C     G
 
@@ -57,7 +57,7 @@ Chords are waiting between the lines
 
 The number in the opening tag is the transposition in semitones. Negative numbers transpose down.
 
-<chordSheet 2>
+<chordSheet 2 source="tabs">
 [Intro]
 Am    F     C     G
 
@@ -74,7 +74,7 @@ No manual rewriting or regret
 
 ==== Example 3 — Extended and slash chords ====
 
-<chordSheet 0>
+<chordSheet 0 source="tabs">
 [Verse]
 Cmaj7        G/B
 Leave a little room to breathe
@@ -97,7 +97,7 @@ The current release brings the completed wishlist together in one workflow. Ever
 
 Inline chords keep compact lead sheets readable. Slash chords expose their bass note separately for themes and export tools.
 
-<chordSheet 0 title="Night Lines" author="Demo Ensemble">
+<chordSheet 0 source="tabs" title="Night Lines" author="Demo Ensemble">
 [Verse]
 Walk [C] home with the melody above us and the (G/B) bass leading down.
 Keep [Am7] time while the [Fadd9] streetlights fade.
@@ -108,7 +108,7 @@ Keep [Am7] time while the [Fadd9] streetlights fade.
 The two chords below exercise both viewport edges. Their popovers stay inside
 the browser while each arrow continues to point at its chord text.
 
-<chordSheet 0 title="Tooltip Edge Check">
+<chordSheet 0 source="tabs" title="Tooltip Edge Check">
 [Viewport edges]
 C                                                       G
 </chordSheet>
@@ -119,7 +119,7 @@ Bars, repeat annotations, unknown stage notes, slash chords, spacing, and
 trailing text must survive parsing without being merged into neighboring
 chords.
 
-<chordSheet 0 title="Long Line Regression">
+<chordSheet 0 source="tabs" title="Long Line Regression">
 [Mixed chord line]
 C | G/B (2x) ??? | Am7    Fadd9 || Dm7/G  outro
 </chordSheet>
@@ -128,24 +128,49 @@ C | G/B (2x) ??? | Am7    Fadd9 || Dm7/G  outro
 
 Guitar chords use a compact visual **Fret** picker: **Open** and the fret numbers identify each actual neck position. Switch the selected shape between **Fretboard** and **Tab** without leaving the popover. Add an exact low-E-to-high-e shape such as ''C@{x,3,2,0,1,0}'' to the song source when the voicing is part of the arrangement. The orange **Pin** is the authored shape; alternatives are temporary previews and never rewrite the song.
 
-<chordSheet 0 title="Voicing Lab">
+<chordSheet 0 source="tabs" title="Voicing Lab">
 [Progression]
 C@{x,3,2,0,1,0}        G        Am       F
 </chordSheet>
 
 ==== Ukulele and song metadata ====
 
-Set ''instrument="ukulele"'' on the opening tag to switch to four-string GCEA diagrams. Title, author, and date become a structured song header.
+Without an instrument attribute, the plugin uses six-string guitar diagrams.
+Add only ''instrument="ukulele"'' to the opening tag to switch the same song
+to four-string GCEA diagrams.
 
-<chordSheet 0 instrument="ukulele" title="Four Strings, One Song" author="Chordsheets Demo" date="2026-07-30">
-[Verse]
+Copy this HTML-style example into a DokuWiki page:
+
+<code html>
+<chordSheet 0 source="tabs" instrument="ukulele">
+[Progression]
 C        Am       F        G
-Four strings, the same transposable song syntax.
 </chordSheet>
+</code>
+
+The two live examples below use exactly the same progression:
+
+**Guitar (default):**
+
+<chordSheet 0 source="tabs" title="Same Song, Guitar">
+[Progression]
+C        Am       F        G
+Six strings are used when no instrument is specified.
+</chordSheet>
+
+**Ukulele (GCEA):**
+
+<chordSheet 0 source="tabs" instrument="ukulele" title="Same Song, Ukulele" author="Chordsheets Demo" date="2026-07-31">
+[Progression]
+C        Am       F        G
+The added instrument attribute switches the diagrams to four strings.
+</chordSheet>
+
+Optional ''title'', ''author'', and ''date'' attributes create a structured song header.
 
 ==== Standalone JTab chord ====
 
-<chordSheet 0>
+<chordSheet 0 source="tabs">
 %7/2.X/X.7/3.7/4.6/1.X/X[Bm7b5]
 </chordSheet>
 
@@ -157,7 +182,7 @@ This example renders one explicitly authored ''Bm7b5'' shape.
 
 Dedicated blocks keep JTab-compatible tablature and locally rendered ABC notation next to the lyrics.
 
-<chordSheet 0 title="Tab and Notation Study" author="Chordsheets Demo">
+<chordSheet 0 source="tabs" title="Tab and Notation Study" author="Chordsheets Demo">
 [Tablature]
 {{tab}}
 $2 0 1 3 $1 0 3 | 022100
@@ -182,7 +207,7 @@ Administrators can tune colors, fonts, independent chord and lyric sizes, spacin
 Wrap a plain-text song in ''chordSheet'' tags. Put chords on their own lines and use square brackets for section names.
 
 <code xml>
-<chordSheet 0>
+<chordSheet 0 source="tabs">
 [Intro]
 Am    F     C     G
 

--- a/deployment/tests/demo-landing-page.test.ps1
+++ b/deployment/tests/demo-landing-page.test.ps1
@@ -25,13 +25,13 @@ foreach ($requiredPagePattern in @(
     '====== DokuWiki Chordsheets ======',
     '===== Live demo =====',
     '===== Installation =====',
-    '===== Project & roadmap =====',
+    '===== Project and support =====',
     '\{\{:wiki:logo\.png\?220\|DokuWiki Chordsheets logo\}\}',
-    '<chordSheet 0>',
-    '<chordSheet 2>',
+    '<chordSheet 0[^>]*\bsource="tabs"',
+    '<chordSheet 2[^>]*\bsource="tabs"',
     'Cmaj7',
     'https://github\.com/apazureck/dokuwiki-chordsheets',
-    'https://github\.com/apazureck/dokuwiki-chordsheets/issues/7',
+    'https://github\.com/apazureck/dokuwiki-chordsheets/issues',
     'archive/refs/heads/master\.zip',
     '<code xml>'
 )) {

--- a/docker/smoke-test.ps1
+++ b/docker/smoke-test.ps1
@@ -53,7 +53,7 @@ try {
     }
 
     $rawPage = Invoke-WebRequest -Uri "$baseUrl/doku.php?id=start&do=export_raw" -UseBasicParsing
-    if ($rawPage.Content -notmatch [regex]::Escape('<chordSheet 2>')) {
+    if ($rawPage.Content -notmatch '<chordSheet 2[^>]*\bsource="tabs"') {
         throw 'The transposition example is missing from the start page.'
     }
 

--- a/script.js
+++ b/script.js
@@ -891,10 +891,114 @@ function runSongHighlighter(scope) {
     return initializedCount;
 }
 
+function findChordSheetSourcePanel(tablist, panelId, ownerDocument) {
+    "use strict";
+    var wrapper = tablist.closest ? tablist.closest(".chord-sheet-example") : null;
+    var panels;
+    var i;
+
+    if (wrapper) {
+        panels = wrapper.querySelectorAll('[role="tabpanel"]');
+        for (i = 0; i < panels.length; i++) {
+            if (panels[i].id === panelId) return panels[i];
+        }
+        return null;
+    }
+    return ownerDocument.getElementById ? ownerDocument.getElementById(panelId) : null;
+}
+
+function selectChordSheetSourceTab(tablist, selectedTab, moveFocus) {
+    "use strict";
+    var tabs = tablist.querySelectorAll('[role="tab"]');
+    var ownerDocument = selectedTab.ownerDocument || document;
+    var panel;
+    var selected;
+    var i;
+
+    for (i = 0; i < tabs.length; i++) {
+        selected = tabs[i] === selectedTab;
+        tabs[i].setAttribute("aria-selected", selected ? "true" : "false");
+        tabs[i].setAttribute("tabindex", selected ? "0" : "-1");
+        panel = findChordSheetSourcePanel(tablist, tabs[i].getAttribute("aria-controls"), ownerDocument);
+        if (panel) panel.hidden = !selected;
+    }
+    if (moveFocus && selectedTab.focus) selectedTab.focus();
+}
+
+function handleChordSheetSourceTabClick(event) {
+    "use strict";
+    selectChordSheetSourceTab(this, event.currentTarget, false);
+}
+
+function handleChordSheetSourceTabKeydown(event) {
+    "use strict";
+    var tablist = this;
+    var tabs = tablist.querySelectorAll('[role="tab"]');
+    var currentIndex = -1;
+    var nextIndex;
+    var i;
+
+    for (i = 0; i < tabs.length; i++) {
+        if (tabs[i] === event.currentTarget) currentIndex = i;
+    }
+    if (currentIndex < 0) return;
+
+    if (event.key === "ArrowRight") {
+        nextIndex = (currentIndex + 1) % tabs.length;
+    } else if (event.key === "ArrowLeft") {
+        nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+    } else if (event.key === "Home") {
+        nextIndex = 0;
+    } else if (event.key === "End") {
+        nextIndex = tabs.length - 1;
+    } else {
+        return;
+    }
+
+    event.preventDefault();
+    selectChordSheetSourceTab(tablist, tabs[nextIndex], true);
+}
+
+function initializeChordSheetSourceTabs(scope) {
+    "use strict";
+    var tablists = getScopedElements(scope, ".chord-sheet-example-tabs");
+    var initializedCount = 0;
+    var tabs;
+    var selectedTab;
+    var i;
+    var j;
+
+    for (i = 0; i < tablists.length; i++) {
+        tabs = tablists[i].querySelectorAll('[role="tab"]');
+        if (tabs.length < 2) continue;
+        if (tablists[i]._chordSheetSourceTabsBound) {
+            selectedTab = null;
+            for (j = 0; j < tabs.length; j++) {
+                if (tabs[j].getAttribute("aria-selected") === "true") {
+                    selectedTab = tabs[j];
+                }
+            }
+            selectChordSheetSourceTab(tablists[i], selectedTab || tabs[0], false);
+            tablists[i].hidden = false;
+            continue;
+        }
+        for (j = 0; j < tabs.length; j++) {
+            tabs[j].addEventListener("click", handleChordSheetSourceTabClick.bind(tablists[i]));
+            tabs[j].addEventListener("keydown", handleChordSheetSourceTabKeydown.bind(tablists[i]));
+        }
+        tablists[i].hidden = false;
+        tablists[i]._chordSheetSourceTabsBound = true;
+        initializedCount++;
+    }
+    return initializedCount;
+}
+
 function initializeChordSheets(scope) {
     "use strict";
     var root = scope || document;
-    if (runSongHighlighter(root) < 1) return;
+    var renderedSongs = runSongHighlighter(root);
+    initializeChordSheetSourceTabs(root);
+    if (renderedSongs < 1) return;
     if (typeof jtab !== "undefined" && jtab.renderimplicit) jtab.renderimplicit(root);
     if (typeof ukulele !== "undefined" && ukulele.renderimplicit) ukulele.renderimplicit(root);
     renderNotationBlocks(root);
@@ -909,9 +1013,42 @@ function initializeUpdatedChordSheets(event) {
     initializeChordSheetColorSettings(root);
 }
 
+function restoreChordSheetHashTarget() {
+    "use strict";
+    var hash;
+    var targetId;
+    var target;
+
+    if (typeof window === "undefined" || !window.location) return false;
+    if (getScopedElements(document, ".chord-sheet-example-tabs").length < 1) return false;
+    hash = window.location.hash || "";
+    if (hash.charAt(0) !== "#" || hash.length < 2) return false;
+    try {
+        targetId = decodeURIComponent(hash.slice(1));
+    } catch (error) {
+        return false;
+    }
+    target = document.getElementById ? document.getElementById(targetId) : null;
+    if (!target || !target.scrollIntoView) return false;
+    target.scrollIntoView({ block: "start" });
+    return true;
+}
+
+function initializeRestoredChordSheetPage(event) {
+    "use strict";
+    if (!event || !event.persisted) return false;
+    ready();
+    restoreChordSheetHashTarget();
+    return true;
+}
+
 function registerDokuWikiContentInitializer() {
     "use strict";
     document.addEventListener("dw_page_loaded", initializeUpdatedChordSheets);
+    if (typeof window !== "undefined" && window.addEventListener) {
+        window.addEventListener("pageshow", initializeRestoredChordSheetPage);
+        window.addEventListener("load", restoreChordSheetHashTarget);
+    }
     if (typeof window !== "undefined" && window.jQuery) {
         window.jQuery(document).on("dw_page_content.chordsheets", function (event, data) {
             var content = data && data.$content;

--- a/style.css
+++ b/style.css
@@ -9,6 +9,84 @@
     vertical-align: middle;
     width: 2.75rem;
 }
+.chord-sheet-example {
+  background: #fffdf6;
+  border: 1px solid #d8cfba;
+  border-radius: 0.9rem;
+  box-shadow: 0 0.35rem 1rem rgba(40, 55, 47, 0.08);
+  margin-block: 1rem 1.5rem;
+  padding: clamp(0.55rem, 1.5vw, 0.9rem);
+}
+
+.chord-sheet-example-tabs {
+  align-items: flex-end;
+  background: #f4efdf;
+  border: 1px solid #d8cfba;
+  border-radius: 0.65rem;
+  display: flex;
+  gap: 0.25rem;
+  margin: 0 0 0.65rem;
+  max-width: 100%;
+  padding: 0.2rem;
+  width: fit-content;
+}
+
+.chord-sheet-example-tabs[hidden],
+.chord-sheet-example-panel[hidden] {
+  display: none;
+}
+
+.chord-sheet-example-tab {
+  appearance: none;
+  background: #f4efdf;
+  border: 2px solid transparent;
+  border-radius: 0.45rem;
+  color: #405347;
+  cursor: pointer;
+  font: 750 0.9rem/1 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  min-height: 2.75rem;
+  min-width: 5.5rem;
+  padding: 0.7rem 1rem;
+}
+
+.chord-sheet-example-tab:hover {
+  background: #e5ddca;
+  color: #28372f;
+}
+
+.chord-sheet-example-tab[aria-selected="true"] {
+  background: #28372f;
+  border-color: #28372f;
+  box-shadow: 0 0.2rem 0 #ee6736;
+  color: #fffdf6;
+  font-weight: 800;
+}
+
+.chord-sheet-example-tab:focus-visible {
+  outline: 3px solid #196f78;
+  outline-offset: 3px;
+  position: relative;
+  z-index: 1;
+}
+
+.chord-sheet-example-source pre {
+  background: #202923;
+  border: 1px solid #405347;
+  border-radius: 0.75rem;
+  color: #fffdf6;
+  margin: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  white-space: pre;
+}
+
+.chord-sheet-example-source code {
+  background: transparent;
+  color: inherit;
+  font: 0.9rem/1.55 ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  padding: 0;
+}
 .song-with-chords {
     background-color: transparent;
     font-family: 'Courier New', Courier, monospace;

--- a/syntax.php
+++ b/syntax.php
@@ -27,6 +27,7 @@ class syntax_plugin_chordsheets extends DokuWiki_Syntax_Plugin
         'export_include_metadata' => 1,
         'export_font_family' => 'Georgia, "Times New Roman", serif',
     );
+    private $sourceCapture = null;
 
     public function getType() { return 'formatting'; }
     public function getAllowedTypes() { return array(); }
@@ -62,13 +63,19 @@ class syntax_plugin_chordsheets extends DokuWiki_Syntax_Plugin
 
     private function parseOptions($tag)
     {
-        $options = array('transpose' => 0, 'instrument' => 'guitar', 'metadata' => array());
+        $options = array(
+            'transpose' => 0,
+            'instrument' => 'guitar',
+            'metadata' => array(),
+            'source_tabs' => false,
+            'source_tag' => (string) $tag,
+        );
         $body = preg_replace('/^<chordSheet|>$/i', '', (string) $tag);
         if (preg_match('/(?:^|\\s)([-+]?\\d+)(?=\\s|$)/', $body, $match)) {
             $options['transpose'] = (int) $match[1];
         }
 
-        preg_match_all('/\\b(transpose|instrument|title|author|date)\\s*=\\s*(["\'])(.*?)\\2/is', $body, $attributes, PREG_SET_ORDER);
+        preg_match_all('/\\b(transpose|instrument|title|author|date|source)\\s*=\\s*(["\'])(.*?)\\2/is', $body, $attributes, PREG_SET_ORDER);
         foreach ($attributes as $attribute) {
             $name = strtolower($attribute[1]);
             $value = $this->normalizeAttribute($attribute[3]);
@@ -78,6 +85,8 @@ class syntax_plugin_chordsheets extends DokuWiki_Syntax_Plugin
                 if (in_array(strtolower($value), array('guitar', 'ukulele'), true)) {
                     $options['instrument'] = strtolower($value);
                 }
+            } elseif ($name === 'source' && strtolower($value) === 'tabs') {
+                $options['source_tabs'] = true;
             } elseif ($name === 'date') {
                 if ($this->isValidDate($value)) {
                     $options['metadata']['date'] = $this->escape($value);
@@ -116,15 +125,24 @@ class syntax_plugin_chordsheets extends DokuWiki_Syntax_Plugin
         list($state, $match) = $data;
         switch ($state) {
             case DOKU_LEXER_ENTER:
+                $this->sourceCapture = !empty($match['source_tabs'])
+                    ? array('source' => $match['source_tag'], 'id' => null)
+                    : null;
                 $this->renderStart($renderer, $match);
                 break;
             case DOKU_LEXER_UNMATCHED:
+                if ($this->sourceCapture !== null) {
+                    $this->sourceCapture['source'] .= $match;
+                }
                 $renderer->doc .= $renderer->_xmlEntities($match);
                 break;
             case DOKU_LEXER_EXIT:
-                $renderer->doc .= '</div></article>';
+                $this->renderEnd($renderer);
                 break;
             case DOKU_LEXER_MATCHED:
+                if ($this->sourceCapture !== null) {
+                    $this->sourceCapture['source'] .= $match;
+                }
                 $renderer->doc .= '<span class="jtab">' . $renderer->_xmlEntities($match) . '</span>';
                 break;
         }
@@ -161,10 +179,36 @@ class syntax_plugin_chordsheets extends DokuWiki_Syntax_Plugin
         $style = $this->styleProperties($settings);
         $attributes[] = 'style="' . $style . '"';
         $bodyAttributes[] = 'style="' . $style . '"';
+        if ($this->sourceCapture !== null) {
+            $exampleId = 'chord-sheet-example-' . $id;
+            $this->sourceCapture['id'] = $exampleId;
+            $renderer->doc .= '<div class="chord-sheet-example">';
+            $renderer->doc .= '<div class="chord-sheet-example-tabs" role="tablist" aria-label="Beispielansicht" hidden>';
+            $renderer->doc .= '<button type="button" class="chord-sheet-example-tab" role="tab" id="' . $exampleId . '-view-tab" aria-controls="' . $exampleId . '-view-panel" aria-selected="true" tabindex="0">Ansicht</button>';
+            $renderer->doc .= '<button type="button" class="chord-sheet-example-tab" role="tab" id="' . $exampleId . '-source-tab" aria-controls="' . $exampleId . '-source-panel" aria-selected="false" tabindex="-1">Source</button>';
+            $renderer->doc .= '</div>';
+            $renderer->doc .= '<div class="chord-sheet-example-panel chord-sheet-example-view" role="tabpanel" id="' . $exampleId . '-view-panel" aria-labelledby="' . $exampleId . '-view-tab">';
+        }
         $renderer->doc .= '<article ' . implode(' ', $attributes) . '>';
         $this->renderMetadata($renderer, $metadata);
         $renderer->doc .= '<div class="cSheetButtonBar"><span class="cSheetButtons"><button type="button" class="cSheetExportButton" onclick="cSheetExportToWord(' . $id . ')" aria-label="Copy this chord sheet for use in a document">Copy for Word</button></span></div>';
         $renderer->doc .= '<div ' . implode(' ', $bodyAttributes) . '>';
+    }
+
+    private function renderEnd(Doku_Renderer $renderer)
+    {
+        $renderer->doc .= '</div></article>';
+        if ($this->sourceCapture === null) {
+            return;
+        }
+
+        $exampleId = $this->sourceCapture['id'];
+        $source = $this->sourceCapture['source'] . '</chordSheet>';
+        $renderer->doc .= '</div>';
+        $renderer->doc .= '<div class="chord-sheet-example-panel chord-sheet-example-source" role="tabpanel" id="' . $exampleId . '-source-panel" aria-labelledby="' . $exampleId . '-source-tab" hidden>';
+        $renderer->doc .= '<pre tabindex="0" aria-label="DokuWiki-Quelltext"><code>' . $renderer->_xmlEntities($source) . '</code></pre>';
+        $renderer->doc .= '</div></div>';
+        $this->sourceCapture = null;
     }
 
     private function renderMetadata(Doku_Renderer $renderer, $metadata)


### PR DESCRIPTION
## What
- add opt-in Ansicht/Source tabs for each individual chord sheet
- add guitar/ukulele demo examples and improve source-copy documentation
- restore fragment navigation after late rendering and scope tab panels locally
- visually separate each chord sheet switcher from surrounding DokuWiki sections

## Testing
- 80 Node tests pass
- PHP syntax tests pass
- Docker DokuWiki smoke test passes
- deployment policy and artifact tests pass
- browser acceptance completed on the local demo

## Deployment
Required before the protected demo environment can deploy this commit from master.